### PR TITLE
Implement `Caller#export`

### DIFF
--- a/ext/src/ruby_api/convert.rs
+++ b/ext/src/ruby_api/convert.rs
@@ -1,8 +1,8 @@
-use crate::{err, error, helpers::WrappedStruct};
+use crate::{err, error};
 use magnus::{Error, TypedData, Value};
 use wasmtime::{ExternRef, Val, ValType};
 
-use super::{func::Func, memory::Memory, store::Store};
+use super::{func::Func, memory::Memory, store::StoreContextValue};
 
 pub trait ToRubyValue {
     fn to_ruby_value(&self) -> Result<Value, Error>;
@@ -79,9 +79,9 @@ impl ToExtern for Value {
     }
 }
 
-pub trait WrapWasmtimeType<T>
+pub trait WrapWasmtimeType<'a, T>
 where
     T: TypedData,
 {
-    fn wrap_wasmtime_type(&self, store: WrappedStruct<Store>) -> Result<T, Error>;
+    fn wrap_wasmtime_type(&self, store: StoreContextValue<'a>) -> Result<T, Error>;
 }

--- a/ext/src/ruby_api/instance.rs
+++ b/ext/src/ruby_api/instance.rs
@@ -101,7 +101,9 @@ impl Instance {
         for export in self.inner.exports(&mut ctx) {
             let export_name: RString = export.name().into();
             let wrapped_store = self.store.clone();
-            let wrapped_export = export.into_extern().wrap_wasmtime_type(wrapped_store)?;
+            let wrapped_export = export
+                .into_extern()
+                .wrap_wasmtime_type(wrapped_store.into())?;
             hash.aset(export_name, wrapped_export)?;
         }
 
@@ -120,7 +122,9 @@ impl Instance {
             .inner
             .get_export(store.context_mut(), unsafe { str.as_str()? });
         match export {
-            Some(export) => export.wrap_wasmtime_type(self.store.clone()).map(Some),
+            Some(export) => export
+                .wrap_wasmtime_type(self.store.clone().into())
+                .map(Some),
             None => Ok(None),
         }
     }
@@ -147,7 +151,7 @@ impl Instance {
 
         let store: &Store = self.store.try_convert()?;
         let func = self.get_func(store.context_mut(), unsafe { name.as_str()? })?;
-        Func::invoke(store, &func, &args[1..]).map_err(|e| e.into())
+        Func::invoke(&self.store.clone().into(), &func, &args[1..]).map_err(|e| e.into())
     }
 
     fn get_func(

--- a/ext/src/ruby_api/linker.rs
+++ b/ext/src/ruby_api/linker.rs
@@ -99,7 +99,7 @@ impl Linker {
     /// @param mod [String] Module name
     /// @param name [String] Import name
     /// @param type [FuncType]
-    /// @param block [Block] See {Func#new} for block argument details.
+    /// @param block [Block] See {Func.new} for block argument details.
     /// @return [void]
     /// @see Func.new
     pub fn func_new(&self, args: &[Value]) -> Result<(), Error> {
@@ -146,7 +146,7 @@ impl Linker {
 
         match ext {
             None => Ok(None),
-            Some(ext) => ext.wrap_wasmtime_type(s).map(Some),
+            Some(ext) => ext.wrap_wasmtime_type(s.into()).map(Some),
         }
     }
 
@@ -271,7 +271,7 @@ impl Linker {
         self.inner
             .borrow()
             .get_default(store.context_mut(), unsafe { module.as_str() }?)
-            .map(|func| Func::from_inner(s, func))
+            .map(|func| Func::from_inner(s.into(), func))
             .map_err(|e| error!("{}", e))
     }
 }

--- a/spec/unit/func_spec.rb
+++ b/spec/unit/func_spec.rb
@@ -102,6 +102,47 @@ module Wasmtime
       expect(called).to be true
     end
 
+    describe "Caller" do
+      it "exposes memory and func for the duration of the call only" do
+        engine = Engine.new
+        mod = Module.new(engine, <<~WAT)
+          (module
+            (import "" "" (func))
+            (import "" "" (func))
+            (memory (export "mem") 1)
+            (export "f1_export" (func 1))
+            (start 0))
+        WAT
+        store = Store.new(engine)
+        calls = 0
+
+        mem = nil
+        f1_export = nil
+        caller = nil
+
+        f0 = Func.new(store, FuncType.new([], [])) do |c|
+          caller = c
+          calls += 1
+
+          mem = caller.export("mem").to_memory
+          mem.write(0, "foo")
+          expect(mem.read(0, 3)).to eq("foo")
+
+          f1_export = caller.export("f1_export").to_func
+          f1_export.call
+        end
+        f1 = Func.new(store, FuncType.new([], [])) { calls += 1 }
+
+        Instance.new(store, mod, [f0, f1])
+        expect(calls).to eq(2)
+
+        message = "Caller outlived its Func execution"
+        expect { caller.export("f1_export") }.to raise_error(Wasmtime::Error, message)
+        expect { mem.read(0, 3) }.to raise_error(Wasmtime::Error, message)
+        expect { f1_export.call }.to raise_error(Wasmtime::Error, message)
+      end
+    end
+
     private
 
     def roundtrip_value(type, value)
@@ -112,10 +153,6 @@ module Wasmtime
     def build_func(params, results, &block)
       store = Store.new(engine, {})
       Func.new(store, FuncType.new(params, results), &block)
-    end
-
-    # Used to test that you can send a `Method` object with `method(:foo)`
-    def noop
     end
   end
 end


### PR DESCRIPTION
Implement `Caller#export` which allows getting a instance's memories or funcs from a `Caller`.

This is a a little odd because the caller itself only "lives" for the duration of call, but we can't control the lifetime of Ruby objects we hand out:

```ruby
Func.new(...) do |caller|
  $yes_i_can_do_this = caller
end
```

The approach I'm taking here is to model a Caller's "context" as an `Option`. While the func is being called, it'll be `Some`, but we'll change it to `None` before exiting the func call.

Thus extracting the context from a `Caller` can fail. That's implemented with an `Error` that gets surfaced as  Ruby exception. See the added test.

---

This PR also makes it easy to implement funcrefs: https://github.com/bytecodealliance/wasmtime-rb/compare/caller-extern...funcref-bindings