### PR TITLE
Add hard-mode CI step with `GC.stress`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Run ruby tests
         run: bundle exec rake spec
 
+      - name: Run ruby tests (hard-mode with GC.stress)
+        run: bundle exec rake spec
+        env:
+          GC_STRESS: "true"
+
       - name: Lint ruby
         run: bundle exec rake standard
 


### PR DESCRIPTION
This PR adds a step in CI which runs tests with `GC.stress`. This should sus out any strange GC related bugs before they are merged.