### PR TITLE
Add `Module.deserialize_file`

### DIFF
--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "tempfile"
+require "securerandom"
 
 module Wasmtime
   RSpec.describe Module do
@@ -14,34 +15,32 @@ module Wasmtime
 
     describe(".deserialize_file") do
       it("can deserialize a module from a file") do
-        tmpfile = Tempfile.new(["deserialize-file", ".so"])
-        tmpfile.write(Module.new(engine, "(module)").serialize)
-        tmpfile.close
+        tmpfile = create_tmpfile(Module.new(engine, "(module)").serialize)
+        mod = Module.deserialize_file(engine, tmpfile)
 
-        begin
-          mod = Module.deserialize_file(engine, tmpfile.path)
-          expect(mod.serialize).to eq(Module.new(engine, "(module)").serialize)
-        ensure
-          tmpfile.unlink
-        end
+        expect(mod.serialize).to eq(Module.new(engine, "(module)").serialize)
       end
 
       it("deserialize from a module multiple times") do
-        tmpfile = Tempfile.new(["deserialize-file", ".so"])
-        tmpfile.write(Module.new(engine, wat).serialize)
-        tmpfile.close
+        tmpfile = create_tmpfile(Module.new(engine, wat).serialize)
 
-        begin
-          mod_one = Module.deserialize_file(engine, tmpfile.path)
-          mod_two = Module.deserialize_file(engine, tmpfile.path)
-          expected = Module.new(engine, wat).serialize
+        mod_one = Module.deserialize_file(engine, tmpfile)
+        mod_two = Module.deserialize_file(engine, tmpfile)
+        expected = Module.new(engine, wat).serialize
 
-          expect(mod_one.serialize).to eq(expected)
-          expect(mod_two.serialize).to eq(expected)
-        ensure
-          tmpfile.unlink
-        end
+        expect(mod_one.serialize).to eq(expected)
+        expect(mod_two.serialize).to eq(expected)
       end
+
+      def create_tmpfile(content)
+        uuid = SecureRandom.uuid
+        path = File.join(tmpdir, uuid)
+        File.write(path, content)
+        path
+      end
+
+      let(:tmpdir) { Dir.mktmpdir }
+      after(:each) { FileUtils.rm_rf(tmpdir) }
     end
 
     describe(".deserialize") do

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -16,7 +16,11 @@ module Wasmtime
     describe(".deserialize_file") do
       let(:tmpdir) { Dir.mktmpdir }
 
-      after(:each) { FileUtils.rm_rf(tmpdir) }
+      after(:each) do
+        FileUtils.rm_rf(tmpdir)
+      rescue Errno::EACCES => e
+        warn "WARN: Failed to remove #{tmpdir} (#{e})"
+      end
 
       it("can deserialize a module from a file") do
         tmpfile = create_tmpfile(Module.new(engine, "(module)").serialize)

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -1,14 +1,47 @@
 require "spec_helper"
+require "tempfile"
 
 module Wasmtime
   RSpec.describe Module do
     let(:engine) { Engine.new(Wasmtime::Config.new) }
 
     it("can be serialized and deserialized") do
-      mod = Module.new(engine, "(module)")
+      mod = Module.new(engine, wat)
       serialized = mod.serialize
       deserialized = Module.deserialize(engine, serialized)
       expect(deserialized.serialize).to eq(serialized)
+    end
+
+    describe(".deserialize_file") do
+      it("can deserialize a module from a file") do
+        tmpfile = Tempfile.new(["deserialize-file", ".so"])
+        tmpfile.write(Module.new(engine, "(module)").serialize)
+        tmpfile.flush
+
+        begin
+          mod = Module.deserialize_file(engine, tmpfile.path)
+          expect(mod.serialize).to eq(Module.new(engine, "(module)").serialize)
+        ensure
+          tmpfile.close
+        end
+      end
+
+      it("deserialize from a module multiple times") do
+        tmpfile = Tempfile.new(["deserialize-file", ".so"])
+        tmpfile.write(Module.new(engine, wat).serialize)
+        tmpfile.flush
+
+        begin
+          mod_one = Module.deserialize_file(engine, tmpfile.path)
+          mod_two = Module.deserialize_file(engine, tmpfile.path)
+          expected = Module.new(engine, wat).serialize
+
+          expect(mod_one.serialize).to eq(expected)
+          expect(mod_two.serialize).to eq(expected)
+        ensure
+          tmpfile.close
+        end
+      end
     end
 
     describe(".deserialize") do

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -16,20 +16,20 @@ module Wasmtime
       it("can deserialize a module from a file") do
         tmpfile = Tempfile.new(["deserialize-file", ".so"])
         tmpfile.write(Module.new(engine, "(module)").serialize)
-        tmpfile.flush
+        tmpfile.close
 
         begin
           mod = Module.deserialize_file(engine, tmpfile.path)
           expect(mod.serialize).to eq(Module.new(engine, "(module)").serialize)
         ensure
-          tmpfile.close
+          tmpfile.unlink
         end
       end
 
       it("deserialize from a module multiple times") do
         tmpfile = Tempfile.new(["deserialize-file", ".so"])
         tmpfile.write(Module.new(engine, wat).serialize)
-        tmpfile.flush
+        tmpfile.close
 
         begin
           mod_one = Module.deserialize_file(engine, tmpfile.path)
@@ -39,7 +39,7 @@ module Wasmtime
           expect(mod_one.serialize).to eq(expected)
           expect(mod_two.serialize).to eq(expected)
         ensure
-          tmpfile.close
+          tmpfile.unlink
         end
       end
     end

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -14,6 +14,10 @@ module Wasmtime
     end
 
     describe(".deserialize_file") do
+      let(:tmpdir) { Dir.mktmpdir }
+
+      after(:each) { FileUtils.rm_rf(tmpdir) }
+
       it("can deserialize a module from a file") do
         tmpfile = create_tmpfile(Module.new(engine, "(module)").serialize)
         mod = Module.deserialize_file(engine, tmpfile)
@@ -35,12 +39,9 @@ module Wasmtime
       def create_tmpfile(content)
         uuid = SecureRandom.uuid
         path = File.join(tmpdir, uuid)
-        File.write(path, content)
+        File.binwrite(path, content)
         path
       end
-
-      let(:tmpdir) { Dir.mktmpdir }
-      after(:each) { FileUtils.rm_rf(tmpdir) }
     end
 
     describe(".deserialize") do

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -38,7 +38,7 @@ module Wasmtime
 
       def create_tmpfile(content)
         uuid = SecureRandom.uuid
-        path = File.join(tmpdir, uuid)
+        path = File.join(tmpdir, "deserialize-file-test-#{uuid}.so")
         File.binwrite(path, content)
         path
       end


### PR DESCRIPTION
This PR adds support for [`wasmtime::Module::deserialize_file`](https://docs.wasmtime.dev/api/wasmtime/struct.Module.html#method.deserialize_file).

> This method is provided because it can be faster than [deserialize](https://docs.wasmtime.dev/api/wasmtime/struct.Module.html#method.deserialize) since the data doesn’t need to be copied around, but rather the module can be used directly from an mmap’d view of the file provided.