### PR TITLE
YARD doc generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,25 @@ jobs:
 
       - name: Lint rust
         run: cargo clippy && cargo fmt --check
+
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Remove Gemfile.lock
+        run: rm Gemfile.lock
+
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
+        with:
+          ruby-version: "3.1"
+          rustup-toolchain: "nightly"
+          bundler-cache: true
+          cargo-cache: true
+          cache-version: v1
+
+      - name: Compile rust ext
+        run: bundle exec rake compile
+
+      - name: Generate doc
+        run: bundle exec rake doc

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,3 @@
+--plugin rustdoc
+lib
+tmp/doc/ext.json

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ group :development do
   gem "standard", "~> 1.3"
   gem "get_process_mem"
   gem "ruby-lsp", require: false
+  gem "yard", require: false
+  gem "yard-rustdoc", "~> 0.1", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,12 @@ GEM
     syntax_tree (4.3.0)
       prettier_print (>= 1.0.2)
     unicode-display_width (2.3.0)
+    webrick (1.7.0)
+    yard (0.9.28)
+      webrick (~> 1.7.0)
+    yard-rustdoc (0.1.0)
+      syntax_tree (~> 4.0)
+      yard (~> 0.9)
 
 PLATFORMS
   arm64-darwin-21
@@ -84,6 +90,8 @@ DEPENDENCIES
   ruby-lsp
   standard (~> 1.3)
   wasmtime-rb!
+  yard
+  yard-rustdoc (~> 0.1)
 
 BUNDLED WITH
    2.3.24

--- a/ext/src/ruby_api/config.rs
+++ b/ext/src/ruby_api/config.rs
@@ -3,6 +3,9 @@ use magnus::{function, method, Error, Module, Object};
 use std::cell::RefCell;
 use wasmtime::Config as ConfigImpl;
 
+/// @yard
+/// Wasmtime {Engine} configuration.
+/// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Config.html Wasmtime's Rust doc
 #[derive(Clone, Debug)]
 #[magnus::wrap(class = "Wasmtime::Config")]
 pub struct Config {
@@ -10,6 +13,8 @@ pub struct Config {
 }
 
 impl Config {
+    /// @yard
+    /// @return [Config]
     pub fn new() -> Self {
         Self {
             inner: RefCell::new(ConfigImpl::new()),
@@ -20,14 +25,23 @@ impl Config {
         self.inner.borrow().clone()
     }
 
+    /// @yard
+    /// @def epoch_interruption=(enabled)
+    /// @param enabled [Boolean]
     pub fn set_epoch_interruption(&self, enabled: bool) {
         self.inner.borrow_mut().epoch_interruption(enabled);
     }
 
+    /// @yard
+    /// @def max_wasm_stack=(size)
+    /// @param size [Integer]
     pub fn set_max_wasm_stack(&self, size: usize) {
         self.inner.borrow_mut().max_wasm_stack(size);
     }
 
+    /// @yard
+    /// @def wasm_multi_memory=(enabled)
+    /// @param enabled [Boolean]
     pub fn set_wasm_multi_memory(&self, enabled: bool) {
         self.inner.borrow_mut().wasm_multi_memory(enabled);
     }

--- a/ext/src/ruby_api/engine.rs
+++ b/ext/src/ruby_api/engine.rs
@@ -5,6 +5,7 @@ use wasmtime::Engine as EngineImpl;
 
 /// @yard
 /// Represents a Wasmtime execution engine.
+/// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Engine.html Wasmtime's Rust doc
 #[derive(Clone)]
 #[magnus::wrap(class = "Wasmtime::Engine")]
 pub struct Engine {
@@ -14,7 +15,7 @@ pub struct Engine {
 impl Engine {
     /// @yard
     /// @def new(config)
-    /// @param config [Wasmtime::Configuration]
+    /// @param config [Configuration]
     pub fn new(args: &[Value]) -> Result<Self, Error> {
         let args = scan_args::scan_args::<(), (Option<Value>,), (), (), (), ()>(args)?;
         let (config,) = args.optional;
@@ -36,9 +37,18 @@ impl Engine {
         EngineImpl::same(self.get(), other.get())
     }
 
-    pub fn precompile_module(&self, string: RString) -> Result<RString, Error> {
+    /// @yard
+    /// AoT compile a WebAssembly text or WebAssembly binary module for later use.
+    ///
+    /// The compiled module can be instantiated using {Module.deserialize}.
+    ///
+    /// @def precompile_module(wat_or_wasm)
+    /// @param wat_or_wasm [String] The String of WAT or Wasm.
+    /// @return [String] Binary String of the compiled module.
+    /// @see Module.deserialize
+    pub fn precompile_module(&self, wat_or_wasm: RString) -> Result<RString, Error> {
         self.inner
-            .precompile_module(unsafe { string.as_slice() })
+            .precompile_module(unsafe { wat_or_wasm.as_slice() })
             .map(|bytes| RString::from_slice(&bytes))
             .map_err(|e| error!("{}", e.to_string()))
     }

--- a/ext/src/ruby_api/engine.rs
+++ b/ext/src/ruby_api/engine.rs
@@ -3,6 +3,8 @@ use crate::error;
 use magnus::{function, method, scan_args, Error, Module, Object, RString, Value};
 use wasmtime::Engine as EngineImpl;
 
+/// @yard
+/// Represents a Wasmtime execution engine.
 #[derive(Clone)]
 #[magnus::wrap(class = "Wasmtime::Engine")]
 pub struct Engine {
@@ -10,6 +12,9 @@ pub struct Engine {
 }
 
 impl Engine {
+    /// @yard
+    /// @def new(config)
+    /// @param config [Wasmtime::Configuration]
     pub fn new(args: &[Value]) -> Result<Self, Error> {
         let args = scan_args::scan_args::<(), (Option<Value>,), (), (), (), ()>(args)?;
         let (config,) = args.optional;

--- a/ext/src/ruby_api/func.rs
+++ b/ext/src/ruby_api/func.rs
@@ -9,13 +9,15 @@ use crate::error;
 use magnus::{
     block::Proc, function, gc, memoize, method, r_typed_data::DataTypeBuilder,
     scan_args::scan_args, value::BoxValue, DataTypeFunctions, Error, Exception, Module as _,
-    Object, RArray, RClass, RHash, RString, TryConvert, TypedData, Value, QNIL,
+    Object, RArray, RClass, RString, TryConvert, TypedData, Value, QNIL,
 };
 use std::cell::RefCell;
 use wasmtime::{
     AsContextMut, Caller as CallerImpl, Extern, ExternType, Func as FuncImpl, Trap, Val,
 };
 
+/// @yard
+/// Represents a WebAssembly Function
 #[derive(TypedData, Debug)]
 #[magnus(class = "Wasmtime::Func", mark, size, free_immediatly)]
 pub struct Func {
@@ -40,8 +42,18 @@ unsafe impl Sync for ShareableProc {}
 unsafe impl Send for Func {}
 
 impl Func {
+    /// @yard
+    ///
+    /// @def new(store, type, callable, &block)
+    /// @param store [Wasmtime::Store]
+    /// @param type [Wasmtime::FuncType]
+    /// @param block [Block] The funcs's implementation
+    /// @return [Wasmtime::Func]
+    ///
+    /// @example
+    ///   store = Wasmtime::Store.new(Wasmtime::Engine.new)
     pub fn new(args: &[Value]) -> Result<Self, Error> {
-        let args = scan_args::<(Value, &FuncType), (), (), (), RHash, Proc>(args)?;
+        let args = scan_args::<(Value, &FuncType), (), (), (), (), Proc>(args)?;
         let (s, functype) = args.required;
         let callable = args.block;
 
@@ -64,6 +76,8 @@ impl Func {
         self.inner
     }
 
+    /// @yard
+    /// Func#call method
     pub fn call(&self, args: &[Value]) -> Result<Value, Error> {
         let store: &Store = self.store.try_convert()?;
         Self::invoke(store, &self.inner, args).map_err(|e| e.into())

--- a/ext/src/ruby_api/func_type.rs
+++ b/ext/src/ruby_api/func_type.rs
@@ -13,6 +13,8 @@ define_rb_intern!(
     EXTERNREF => "externref",
 );
 
+/// @yard
+/// Represents a Func's signature
 #[derive(Clone, Debug)]
 #[magnus::wrap(class = "Wasmtime::FuncType")]
 pub struct FuncType {
@@ -26,6 +28,20 @@ impl FuncType {
 }
 
 impl FuncType {
+    /// @yard
+    ///
+    /// A descriptor for a function in a WebAssembly module.
+    /// WebAssembly functions can have 0 or more parameters and results. Each param
+    /// must be a valid WebAssembly type represented as a symbol. The valid symbols are:
+    /// +:i32+, +:i64+, +:f32+, +:f64+, +:v128+, +:funcref+, +:externref+.
+    ///
+    /// @def new(params, results)
+    /// @param params [Array<Symbol>] The function's parameter types
+    /// @param results [Array<Symbol>] The function's result types
+    /// @return [Wasmtime::FuncType]
+    ///
+    /// @example +FuncType+ that takes 2 +i32+s and returns 1 +i32+
+    ///  FuncType.new([:i32, :i32], [:i32])
     pub fn new(params: RArray, results: RArray) -> Result<Self, Error> {
         let inner = FuncTypeImpl::new(params.to_val_type_vec()?, results.to_val_type_vec()?);
         Ok(Self { inner })

--- a/ext/src/ruby_api/func_type.rs
+++ b/ext/src/ruby_api/func_type.rs
@@ -14,7 +14,8 @@ define_rb_intern!(
 );
 
 /// @yard
-/// Represents a Func's signature
+/// Represents a Func's signature.
+/// @see https://docs.rs/wasmtime/latest/wasmtime/struct.FuncType.html Wasmtime's Rust doc
 #[derive(Clone, Debug)]
 #[magnus::wrap(class = "Wasmtime::FuncType")]
 pub struct FuncType {
@@ -29,27 +30,31 @@ impl FuncType {
 
 impl FuncType {
     /// @yard
-    ///
     /// A descriptor for a function in a WebAssembly module.
     /// WebAssembly functions can have 0 or more parameters and results. Each param
     /// must be a valid WebAssembly type represented as a symbol. The valid symbols are:
     /// +:i32+, +:i64+, +:f32+, +:f64+, +:v128+, +:funcref+, +:externref+.
     ///
     /// @def new(params, results)
-    /// @param params [Array<Symbol>] The function's parameter types
-    /// @param results [Array<Symbol>] The function's result types
-    /// @return [Wasmtime::FuncType]
+    /// @param params [Array<Symbol>] The function's parameter types.
+    /// @param results [Array<Symbol>] The function's result types.
+    /// @return [FuncType]
     ///
-    /// @example +FuncType+ that takes 2 +i32+s and returns 1 +i32+
-    ///  FuncType.new([:i32, :i32], [:i32])
+    /// @example +FuncType+ that takes 2 +i32+s and returns 1 +i32+:
+    ///   FuncType.new([:i32, :i32], [:i32])
     pub fn new(params: RArray, results: RArray) -> Result<Self, Error> {
         let inner = FuncTypeImpl::new(params.to_val_type_vec()?, results.to_val_type_vec()?);
         Ok(Self { inner })
     }
 
+    /// @yard
+    /// @return [Array<Symbol>] The function's parameter types.
     pub fn params(&self) -> Vec<Symbol> {
         self.get().params().map(ToSym::to_sym).collect()
     }
+
+    /// @yard
+    /// @return [Array<Symbol>] The function's result types.
     pub fn results(&self) -> Vec<Symbol> {
         self.get().results().map(ToSym::to_sym).collect()
     }

--- a/ext/src/ruby_api/instance.rs
+++ b/ext/src/ruby_api/instance.rs
@@ -12,6 +12,9 @@ use magnus::{
 };
 use wasmtime::{Extern, Instance as InstanceImpl, StoreContextMut};
 
+/// @yard
+/// Represents a WebAssembly instance.
+/// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Instance.html Wasmtime's Rust doc
 #[derive(Clone, Debug, TypedData)]
 #[magnus(class = "Wasmtime::Instance", mark, free_immediatly)]
 pub struct Instance {
@@ -28,6 +31,13 @@ impl DataTypeFunctions for Instance {
 }
 
 impl Instance {
+    /// @yard
+    /// @def new(store, mod, imports = [])
+    /// @param store [Store] The store to instantiate the module in.
+    /// @param mod [Module] The module to instantiate.
+    /// @param imports [Array<Func, Memory>]
+    ///   The module's import, in orders that that they show up in the module.
+    /// @return [Instance]
     pub fn new(args: &[Value]) -> Result<Self, Error> {
         let args =
             scan_args::scan_args::<(Value, &Module), (Option<Value>,), (), (), (), ()>(args)?;
@@ -73,6 +83,11 @@ impl Instance {
         Self { inner, store }
     }
 
+    /// @yard
+    /// Returns a Hash of exports where keys are the export name (String).
+    ///
+    /// @def exports
+    /// @return [Hash{String => Func, Memory}]
     pub fn exports(&self) -> Result<RHash, Error> {
         let store = self.store.try_convert::<&Store>()?;
         let mut ctx = store.context_mut();
@@ -88,6 +103,12 @@ impl Instance {
         Ok(hash)
     }
 
+    /// @yard
+    /// Get an export by name.
+    ///
+    /// @def export(name)
+    /// @param name [String]
+    /// @return [Func, Memory, nil] The export if it exists, nil otherwise.
     pub fn export(&self, str: RString) -> Result<Option<Value>, Error> {
         let store = self.store.try_convert::<&Store>()?;
         let export = self
@@ -99,6 +120,15 @@ impl Instance {
         }
     }
 
+    /// @yard
+    /// Retrieves a Wasm function from the instance and calls it.
+    /// Essentially a shortcut for +instance.export(name).call(...)+.
+    ///
+    /// @def invoke(name, *args)
+    /// @param name [String] The name of function  to run.
+    /// @param (see Func#call)
+    /// @return (see Func#call)
+    /// @see Func#call
     pub fn invoke(&self, args: &[Value]) -> Result<Value, Error> {
         let name: RString = args
             .get(0)

--- a/ext/src/ruby_api/linker.rs
+++ b/ext/src/ruby_api/linker.rs
@@ -16,6 +16,7 @@ use magnus::{
 use std::cell::RefCell;
 use wasmtime::Linker as LinkerImpl;
 
+/// @yard
 #[derive(TypedData)]
 #[magnus(class = "Wasmtime::Linker", size, mark, free_immediatly)]
 pub struct Linker {
@@ -32,6 +33,10 @@ impl DataTypeFunctions for Linker {
 }
 
 impl Linker {
+    /// @yard
+    /// @def new(engine)
+    /// @param engine [Wasmtime::Engine]
+    /// @return [Wasmtime::Linker]
     pub fn new(engine: &Engine) -> Result<Self, Error> {
         Ok(Self {
             inner: RefCell::new(LinkerImpl::new(engine.get())),
@@ -39,10 +44,18 @@ impl Linker {
         })
     }
 
+    /// @yard
+    /// Allow shadowing.
+    /// @def allow_shadowing=(val)
+    /// @param val [Boolean]
     pub fn set_allow_shadowing(&self, val: bool) {
         self.inner.borrow_mut().allow_shadowing(val);
     }
 
+    /// @yard
+    /// Allow unknown exports.
+    /// @def allow_unknown_exports=(val)
+    /// @param val [Boolean]
     pub fn set_allow_unknown_exports(&self, val: bool) {
         self.inner.borrow_mut().allow_unknown_exports(val);
     }

--- a/ext/src/ruby_api/linker.rs
+++ b/ext/src/ruby_api/linker.rs
@@ -17,6 +17,7 @@ use std::cell::RefCell;
 use wasmtime::Linker as LinkerImpl;
 
 /// @yard
+/// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Linker.html Wasmtime's Rust doc
 #[derive(TypedData)]
 #[magnus(class = "Wasmtime::Linker", size, mark, free_immediatly)]
 pub struct Linker {
@@ -35,8 +36,8 @@ impl DataTypeFunctions for Linker {
 impl Linker {
     /// @yard
     /// @def new(engine)
-    /// @param engine [Wasmtime::Engine]
-    /// @return [Wasmtime::Linker]
+    /// @param engine [Engine]
+    /// @return [Linker]
     pub fn new(engine: &Engine) -> Result<Self, Error> {
         Ok(Self {
             inner: RefCell::new(LinkerImpl::new(engine.get())),
@@ -60,6 +61,11 @@ impl Linker {
         self.inner.borrow_mut().allow_unknown_exports(val);
     }
 
+    /// @yard
+    /// Define unknown (unresolved) imports as functions which trap.
+    /// @def define_unknown_imports_as_traps(mod)
+    /// @param mod [Module]
+    /// @return [void]
     pub fn define_unknown_imports_as_traps(&self, module: &Module) -> Result<(), Error> {
         self.inner
             .borrow_mut()
@@ -67,6 +73,13 @@ impl Linker {
             .map_err(|e| error!("{}", e))
     }
 
+    /// @yard
+    /// Define an item in this linker.
+    /// @def define(mod, name, item)
+    /// @param mod [String] Module name
+    /// @param name [String] Import name
+    /// @param item [Func, Memory] The item to define.
+    /// @return [void]
     pub fn define(&self, module: RString, name: RString, item: Value) -> Result<(), Error> {
         let item = item.to_extern()?;
 
@@ -77,6 +90,17 @@ impl Linker {
             .map_err(|e| error!("{}", e))
     }
 
+    /// @yard
+    /// Define a function in this linker.
+    ///
+    /// @def func_new(mod, name, type, &block)
+    ///
+    /// @param mod [String] Module name
+    /// @param name [String] Import name
+    /// @param type [FuncType]
+    /// @param block [Block] See {Func#new} for block argument details.
+    /// @return [void]
+    /// @see Func.new
     pub fn func_new(&self, args: &[Value]) -> Result<(), Error> {
         let args = scan_args::<(RString, RString, &FuncType), (), (), (), RHash, Proc>(args)?;
         let (module, name, ty) = args.required;
@@ -97,6 +121,14 @@ impl Linker {
             .map(|_| ())
     }
 
+    /// @yard
+    /// Looks up a previously defined item in this linker.
+    ///
+    /// @def get(store, mod, name)
+    /// @param store [Store]
+    /// @param mod [String] Module name
+    /// @param name [String] Import name
+    /// @return [Func, Memory, nil] The item if it exists, nil otherwise.
     pub fn get(&self, s: Value, module: RString, name: RString) -> Result<Option<Value>, Error> {
         let store: &Store = s.try_convert()?;
         let ext =
@@ -112,6 +144,14 @@ impl Linker {
         }
     }
 
+    /// @yard
+    /// Defines an entire {Instance} in this linker.
+    ///
+    /// @def instance(store, mod, instance)
+    /// @param store [Store]
+    /// @param mod [String] Module name
+    /// @param instance [Instance]
+    /// @return [void]
     pub fn instance(
         &self,
         store: &Store,
@@ -129,6 +169,14 @@ impl Linker {
             .map(|_| ())
     }
 
+    /// @yard
+    /// Defines automatic instantiation of a {Module} in this linker.
+    ///
+    /// @def module(store, name, mod)
+    /// @param store [Store]
+    /// @param name [String] Module name
+    /// @param mod [Module]
+    /// @return [void]
     pub fn module(&self, store: &Store, name: RString, module: &Module) -> Result<(), Error> {
         self.inner
             .borrow_mut()
@@ -137,6 +185,15 @@ impl Linker {
             .map_err(|e| error!("{}", e))
     }
 
+    /// @yard
+    /// Aliases one item’s name as another.
+    ///
+    /// @def alias(mod, name, as_mod, as_name)
+    /// @param mod [String] The source module name.
+    /// @param name [String] The source item name.
+    /// @param as_mod [String] The destination module name.
+    /// @param as_name [String] The destination item name.
+    /// @return [void]
     pub fn alias(
         &self,
         module: RString,
@@ -156,6 +213,13 @@ impl Linker {
             .map(|_| ())
     }
 
+    /// @yard
+    /// Aliases one module’s name as another.
+    ///
+    /// @def alias(mod, as_mod)
+    /// @param mod [String] Source module name
+    /// @param as_mod [String] Destination module name
+    /// @return [void]
     pub fn alias_module(&self, module: RString, as_module: RString) -> Result<(), Error> {
         self.inner
             .borrow_mut()
@@ -164,6 +228,12 @@ impl Linker {
             .map(|_| ())
     }
 
+    /// @yard
+    /// Instantiates a {Module} in a {Store} using the defined imports in the linker.
+    /// @def instantiate(store, mod)
+    /// @param store [Store]
+    /// @param mod [Module]
+    /// @return [Instance]
     pub fn instantiate(&self, s: Value, module: &Module) -> Result<Instance, Error> {
         let store = s.try_convert::<&Store>()?;
         self.inner
@@ -182,6 +252,12 @@ impl Linker {
             })
     }
 
+    /// @yard
+    /// Returns the “default export” of a module.
+    /// @def get_default(store, mod)
+    /// @param store [Store]
+    /// @param mod [String] Module name
+    /// @return [Func]
     pub fn get_default(&self, s: Value, module: RString) -> Result<Func, Error> {
         let store: &Store = s.try_convert()?;
         self.inner

--- a/ext/src/ruby_api/memory.rs
+++ b/ext/src/ruby_api/memory.rs
@@ -6,6 +6,9 @@ use magnus::{
 };
 use wasmtime::{Extern, Memory as MemoryImpl};
 
+/// @yard
+/// Represents a WebAssembly memory.
+/// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Memory.html Wasmtime's Rust doc
 #[derive(TypedData, Debug)]
 #[magnus(class = "Wasmtime::Memory", mark, size, free_immediatly)]
 pub struct Memory {
@@ -21,6 +24,10 @@ impl DataTypeFunctions for Memory {
 unsafe impl Send for Memory {}
 
 impl Memory {
+    /// @yard
+    /// @def new(store, memtype)
+    /// @param store [Store]
+    /// @param memtype [MemoryType]
     pub fn new(s: Value, memtype: &MemoryType) -> Result<Self, Error> {
         let store: &Store = s.try_convert()?;
 
@@ -34,6 +41,13 @@ impl Memory {
         Self { store, inner }
     }
 
+    /// @yard
+    /// Read +size+ bytes starting at +offset+.
+    ///
+    /// @def read(offset, size)
+    /// @param offset [Integer]
+    /// @param size [Integer]
+    /// @return [String] Binary string of the memory.
     pub fn read(&self, offset: usize, size: usize) -> Result<RString, Error> {
         self.inner
             .data(self.store().context())
@@ -43,6 +57,13 @@ impl Memory {
             .ok_or_else(|| error!("out of bounds memory access"))
     }
 
+    /// @yard
+    /// Write +value+ starting at +offset+.
+    ///
+    /// @def write(offset, value)
+    /// @param offset [Integer]
+    /// @param value [String]
+    /// @return [void]
     pub fn write(&self, offset: usize, value: RString) -> Result<(), Error> {
         let slice = unsafe { value.as_slice() };
 
@@ -51,16 +72,27 @@ impl Memory {
             .map_err(|e| error!("{}", e))
     }
 
+    /// @yard
+    /// Grows a memory by +delta+ pages.
+    /// Raises if the memory grows beyond its limit.
+    ///
+    /// @def grow(delta)
+    /// @param delta [Integer] The number of pages to grow by.
+    /// @return [Integer] The number of pages the memory had before being resized.
     pub fn grow(&self, delta: u64) -> Result<u64, Error> {
         self.inner
             .grow(self.store().context_mut(), delta)
             .map_err(|e| error!("{}", e))
     }
 
+    /// @yard
+    /// @return [Integer] The number of pages of the memory.
     pub fn size(&self) -> u64 {
         self.inner.size(self.store().context())
     }
 
+    /// @yard
+    /// @return [MemoryType]
     pub fn ty(&self) -> MemoryType {
         self.inner.ty(self.store().context()).into()
     }

--- a/ext/src/ruby_api/memory_type.rs
+++ b/ext/src/ruby_api/memory_type.rs
@@ -2,6 +2,8 @@ use super::root;
 use magnus::{function, method, scan_args, Error, Module as _, Object, Value};
 use wasmtime::MemoryType as MemoryTypeImpl;
 
+/// @yard
+/// @see https://docs.rs/wasmtime/latest/wasmtime/struct.MemoryType.html Wasmtime's Rust doc
 #[derive(Clone, Debug)]
 #[magnus::wrap(class = "Wasmtime::MemoryType")]
 pub struct MemoryType {
@@ -9,6 +11,10 @@ pub struct MemoryType {
 }
 
 impl MemoryType {
+    /// @yard
+    /// @def new(min, max = nil)
+    /// @param min [Integer] The minimum memory pages.
+    /// @param max [Integer, nil] The maximum memory pages.
     pub fn new(args: &[Value]) -> Result<Self, Error> {
         let args = scan_args::scan_args::<(u32,), (Option<u32>,), (), (), (), ()>(args)?;
         let (min,) = args.required;
@@ -21,10 +27,14 @@ impl MemoryType {
         &self.inner
     }
 
+    /// @yard
+    /// @return [Integer] The minimum memory pages.
     pub fn minimum(&self) -> u64 {
         self.inner.minimum()
     }
 
+    /// @yard
+    /// @return [Integer, nil] The maximum memory pages.
     pub fn maximum(&self) -> Option<u64> {
         self.inner.maximum()
     }

--- a/ext/src/ruby_api/mod.rs
+++ b/ext/src/ruby_api/mod.rs
@@ -1,3 +1,5 @@
+#![allow(rustdoc::broken_intra_doc_links)]
+#![allow(rustdoc::invalid_html_tags)]
 use magnus::{define_module, memoize, Error, RModule};
 
 mod config;

--- a/ext/src/ruby_api/mod.rs
+++ b/ext/src/ruby_api/mod.rs
@@ -1,5 +1,6 @@
 #![allow(rustdoc::broken_intra_doc_links)]
 #![allow(rustdoc::invalid_html_tags)]
+#![allow(rustdoc::bare_urls)]
 use magnus::{define_module, memoize, Error, RModule};
 
 mod config;

--- a/ext/src/ruby_api/module.rs
+++ b/ext/src/ruby_api/module.rs
@@ -3,6 +3,9 @@ use crate::error;
 use magnus::{function, method, Error, Module as _, Object, RString};
 use wasmtime::Module as ModuleImpl;
 
+/// @yard
+/// Represents a WebAssembly module.
+/// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Module.html Wasmtime's Rust doc
 #[derive(Clone)]
 #[magnus::wrap(class = "Wasmtime::Module", size, free_immediatly)]
 pub struct Module {
@@ -10,6 +13,11 @@ pub struct Module {
 }
 
 impl Module {
+    /// @yard
+    /// @def new(engine, wat_or_wasm)
+    /// @param engine [Wasmtime::Engine]
+    /// @param wat_or_wasm [String] The String of WAT or Wasm.
+    /// @return [Wasmtime::Module]
     pub fn new(engine: &Engine, wat_or_wasm: RString) -> Result<Self, Error> {
         let eng = engine.get();
         // SAFETY: this string is immediately copied and never moved off the stack
@@ -19,12 +27,32 @@ impl Module {
         Ok(Self { inner: module })
     }
 
-    pub fn deserialize(engine: &Engine, wat_or_wasm: RString) -> Result<Self, Error> {
-        unsafe { ModuleImpl::deserialize(engine.get(), wat_or_wasm.as_slice()) }
+    /// @yard
+    /// Instantiates a serialized module coming from either {#serialize} or {Wasmtime::Engine#precompile_module}.
+    ///
+    /// The engine serializing and the engine deserializing must:
+    /// * have the same configuration
+    /// * be of the same gem version
+    ///
+    /// @def deserialize(engine, compiled)
+    /// @param engine [Wasmtime::Engine]
+    /// @param compiled [String] String obtained with either {Wasmtime::Engine#precompile_module} or {#serialize}.
+    /// @return [Wasmtime::Module]
+    pub fn deserialize(engine: &Engine, compiled: RString) -> Result<Self, Error> {
+        // SAFETY: this string is immediately copied and never moved off the stack
+        unsafe { ModuleImpl::deserialize(engine.get(), compiled.as_slice()) }
             .map(|module| Self { inner: module })
             .map_err(|e| error!("Could not deserialize module: {:?}", e.to_string()))
     }
 
+    /// @yard
+    /// Instantiates a serialized module from a file.
+    ///
+    /// @def deserialize_file(engine, path)
+    /// @param engine [Wasmtime::Engine]
+    /// @param path [String]
+    /// @return [Wasmtime::Module]
+    /// @see .deserialize
     pub fn deserialize_file(engine: &Engine, path: RString) -> Result<Self, Error> {
         unsafe { ModuleImpl::deserialize_file(engine.get(), path.as_str()?) }
             .map(|module| Self { inner: module })
@@ -36,6 +64,10 @@ impl Module {
             })
     }
 
+    /// @yard
+    /// Serialize the module.
+    /// @return [String]
+    /// @see .deserialize
     pub fn serialize(&self) -> Result<RString, Error> {
         self.get()
             .serialize()

--- a/ext/src/ruby_api/store.rs
+++ b/ext/src/ruby_api/store.rs
@@ -40,7 +40,8 @@ impl StoreData {
 }
 
 /// @yard
-/// Represents a Store
+/// Represents a WebAssebmly store.
+/// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Store.html Wasmtime's Rust doc
 #[derive(TypedData)]
 #[magnus(class = "Wasmtime::Store", size, mark, free_immediatly)]
 pub struct Store {

--- a/ext/src/ruby_api/store.rs
+++ b/ext/src/ruby_api/store.rs
@@ -39,6 +39,8 @@ impl StoreData {
     }
 }
 
+/// @yard
+/// Represents a Store
 #[derive(TypedData)]
 #[magnus(class = "Wasmtime::Store", size, mark, free_immediatly)]
 pub struct Store {
@@ -56,13 +58,26 @@ unsafe impl Send for Store {}
 unsafe impl Send for StoreData {}
 
 impl Store {
+    /// @yard
+    ///
+    /// @def new(engine, data = nil)
+    /// @param engine [Wasmtime::Engine]
+    ///   The engine for this store.
+    /// @param data [Object]
+    ///   The data attached to the store. Can be retrieved through {Wasmtime::Store#data} and {Wasmtime::Caller#data}.
+    /// @return [Wasmtime::Store]
+    ///
+    /// @example
+    ///   store = Wasmtime::Store.new(Wasmtime::Engine.new)
+    ///
+    /// @example
+    ///   store = Wasmtime::Store.new(Wasmtime::Engine.new, {})
     pub fn new(args: &[Value]) -> Result<Self, Error> {
         let args = scan_args::scan_args::<(&Engine,), (Option<Value>,), (), (), (), ()>(args)?;
         let (engine,) = args.required;
         let (user_data,) = args.optional;
         let user_data = user_data.unwrap_or_else(|| QNIL.into());
 
-        // engine: &Engine, user_data: Value
         let eng = engine.get();
         let store_data = StoreData {
             user_data,
@@ -78,6 +93,8 @@ impl Store {
         Ok(store)
     }
 
+    /// @yard
+    /// @return [Object] The passed in value in {.new}
     pub fn data(&self) -> Value {
         self.context().data().user_data()
     }

--- a/rakelib/doc.rake
+++ b/rakelib/doc.rake
@@ -1,0 +1,66 @@
+require "yard/rake/yardoc_task"
+
+YARD::Rake::YardocTask.new do |t|
+  t.options += ["--fail-on-warn"]
+
+  t.before = -> { require "yard" }
+
+  t.after = -> do
+    require "wasmtime"
+
+    errors = []
+    YARD::Registry.each do |yard_object|
+      case yard_object.type
+      when :module
+        mod = Object.const_get(yard_object.path)
+        errors << "Not a module: #{mod.path}" unless mod.is_a?(::Module)
+      when :class
+        klass = Object.const_get(yard_object.path)
+        errors << "Not a class: #{klass.path}" unless klass.is_a?(::Class)
+      when :method
+        namespace = Object.const_get(yard_object.namespace.path)
+        case yard_object.scope
+        when :class
+          namespace.singleton_method(yard_object.name)
+        when :instance
+          namespace.instance_method(yard_object.name.to_s)
+        else
+          # Unknown scope, we should improve this script
+          errors << "unknown method scope '#{yard_object.scope}' for #{yard_object.path}"
+        end
+      end
+    rescue NameError => e
+      errors << "Documented `#{yard_object.path}` not found: \n  #{e.message.split("\n").first}"
+    end
+
+    if errors.any?
+      errors.each { |error| log.warn(error) }
+      exit 1
+    end
+  end
+end
+
+namespace :doc do
+  task default: [:rustdoc, :yard]
+
+  desc "Run YARD"
+  task yard: "yard"
+
+  desc "Generate Rust documentation as JSON"
+  task :rustdoc do
+    run(<<~CMD)
+      cargo +nightly rustdoc \
+        --target-dir tmp \
+        -p ext \
+        -- -Zunstable-options --output-format json \
+        --document-private-items
+    CMD
+  end
+
+  def run(cmd)
+    system(cmd)
+    fail if $? != 0
+  end
+end
+
+task doc: "doc:default"


### PR DESCRIPTION
First pass at generating documentation using a [YARD plugin I wrote](https://github.com/oxidize-rb/yard-rustdoc). I manually generated the docs and put them on a GH pages for now: https://bytecodealliance.github.io/wasmtime-rb/v2.0.2-alpha1/

Decisions:
- Added an extra validation step to ensure everything that's documented actually exists. That way, a typo in class names or method names won't go unnoticed.
- Make any YARD warning an error, and build the docs in CI. The idea is that anything that breaks the doc shouldn't go in main.
- Document the Ruby specificities thoroughly, but document Wasmtime only briefly. The links to the official doc should suffice, no need to copy everything.