### PR TITLE
Add  new `Wasmtime::Extern` class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
         run: bundle exec rake standard
 
       - name: Lint rust
-        run: cargo clippy && cargo fmt --check
+        run: cargo clippy -- -D warnings && cargo fmt --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,7 @@ version = "0.1.0"
 dependencies = [
  "lazy_static",
  "magnus",
+ "rb-sys",
  "wasmtime",
 ]
 
@@ -637,15 +638,6 @@ checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if",
  "winapi",
-]
-
-[[package]]
-name = "linkify"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96dd5884008358112bc66093362197c7248ece00d46624e2cf71e50029f8cff5"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -867,21 +859,20 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.30"
+version = "0.9.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b22a374fc2e92eb6f49d7efe4eb7663655c6e9455d9259ed3342cc1599da85"
+checksum = "31bb5cd8565cd4dd97dcf7a04e3b4e5401ce379d34496c34e866ce806277a408"
 dependencies = [
- "bindgen",
- "linkify",
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.30"
+version = "0.9.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd23b6dd929b7d50ccb35a6d3aa77dec364328ab9cb304dd32c629332491671"
+checksum = "de4bbf05b48f0c01b9b8e3b26f02769b097185b8d649831c652cb8a9946494a2"
 dependencies = [
+ "bindgen",
  "regex",
  "shell-words",
 ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x64-mingw-ucrt
   x64-mingw32
   x86_64-darwin-19

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -12,4 +12,5 @@ crate-type = ["cdylib"]
 [dependencies]
 lazy_static = "1.4.0"
 magnus = { git = "https://github.com/matsadler/magnus", features = ["rb-sys-interop"] }
+rb-sys = "~0.9.38"
 wasmtime = "2.0.2"

--- a/ext/src/helpers/mod.rs
+++ b/ext/src/helpers/mod.rs
@@ -1,0 +1,3 @@
+mod wrapped_struct;
+
+pub use wrapped_struct::WrappedStruct;

--- a/ext/src/helpers/wrapped_struct.rs
+++ b/ext/src/helpers/wrapped_struct.rs
@@ -13,7 +13,7 @@ pub struct WrappedStruct<T: TypedData> {
 impl<T: TypedData> Clone for WrappedStruct<T> {
     fn clone(&self) -> Self {
         Self {
-            inner: self.inner.clone(),
+            inner: self.inner,
             phantom: PhantomData,
         }
     }
@@ -36,7 +36,7 @@ impl<T: TypedData> WrappedStruct<T> {
     }
 }
 
-impl<'t, T: TypedData> From<WrappedStruct<T>> for Value {
+impl<T: TypedData> From<WrappedStruct<T>> for Value {
     fn from(wrapped_struct: WrappedStruct<T>) -> Self {
         wrapped_struct.to_value()
     }
@@ -53,7 +53,7 @@ impl<T: TypedData> Deref for WrappedStruct<T> {
 impl<T: TypedData> From<T> for WrappedStruct<T> {
     fn from(t: T) -> Self {
         Self {
-            inner: RTypedData::wrap(t).into(),
+            inner: RTypedData::wrap(t),
             phantom: PhantomData,
         }
     }
@@ -76,7 +76,7 @@ where
         })?;
 
         Ok(Self {
-            inner: inner.into(),
+            inner,
             phantom: PhantomData,
         })
     }

--- a/ext/src/helpers/wrapped_struct.rs
+++ b/ext/src/helpers/wrapped_struct.rs
@@ -1,6 +1,5 @@
-use std::{marker::PhantomData, ops::Deref};
-
 use magnus::{error::Error, exception, gc, value::Value, RTypedData, TryConvert, TypedData};
+use std::{marker::PhantomData, ops::Deref};
 
 /// A small wrapper for `RTypedData` that keeps track of the concrete struct
 /// type, and the underlying [`Value`] for GC purposes.
@@ -14,7 +13,7 @@ pub struct WrappedStruct<T: TypedData + 'static> {
 impl<T: TypedData> Clone for WrappedStruct<T> {
     fn clone(&self) -> Self {
         Self {
-            inner: self.inner,
+            inner: self.inner.clone(),
             phantom: PhantomData,
         }
     }
@@ -24,6 +23,11 @@ impl<T: TypedData> WrappedStruct<T> {
     /// Gets the underlying struct.
     pub fn get(&self) -> Result<&T, Error> {
         self.inner.try_convert::<&T>()
+    }
+
+    /// Get the Ruby [`Value`] for this struct.
+    pub fn to_value(&self) -> Value {
+        self.inner
     }
 
     /// Marks the Ruby [`Value`] for GC.

--- a/ext/src/helpers/wrapped_struct.rs
+++ b/ext/src/helpers/wrapped_struct.rs
@@ -1,0 +1,79 @@
+use std::{marker::PhantomData, ops::Deref};
+
+use magnus::{error::Error, exception, gc, value::Value, RTypedData, TryConvert, TypedData};
+
+/// A small wrapper for `RTypedData` that keeps track of the concrete struct
+/// type, and the underlying [`Value`] for GC purposes.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct WrappedStruct<T: TypedData + 'static> {
+    inner: Value,
+    phantom: PhantomData<&'static T>,
+}
+
+impl<T: TypedData> Clone for WrappedStruct<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<T: TypedData> WrappedStruct<T> {
+    /// Gets the underlying struct.
+    pub fn get(&self) -> Result<&T, Error> {
+        self.inner.try_convert::<&T>()
+    }
+
+    /// Marks the Ruby [`Value`] for GC.
+    pub fn mark(&self) {
+        gc::mark(&self.inner);
+    }
+}
+
+impl<'t, T: TypedData> From<WrappedStruct<T>> for Value {
+    fn from(wrapped_struct: WrappedStruct<T>) -> Self {
+        wrapped_struct.inner
+    }
+}
+
+impl<T: TypedData> Deref for WrappedStruct<T> {
+    type Target = Value;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T: TypedData> From<T> for WrappedStruct<T> {
+    fn from(t: T) -> Self {
+        Self {
+            inner: RTypedData::wrap(t).into(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'t, T> TryConvert for WrappedStruct<T>
+where
+    T: TypedData,
+{
+    fn try_convert(val: Value) -> Result<Self, Error> {
+        let inner = RTypedData::from_value(val).ok_or_else(|| {
+            Error::new(
+                exception::type_error(),
+                format!(
+                    "no implicit conversion of {} into {}",
+                    unsafe { val.classname() },
+                    T::class()
+                ),
+            )
+        })?;
+
+        Ok(Self {
+            inner: inner.into(),
+            phantom: PhantomData,
+        })
+    }
+}

--- a/ext/src/lib.rs
+++ b/ext/src/lib.rs
@@ -1,5 +1,6 @@
 use magnus::Error;
 
+mod helpers;
 mod ruby_api;
 
 #[magnus::init]

--- a/ext/src/ruby_api/convert.rs
+++ b/ext/src/ruby_api/convert.rs
@@ -1,8 +1,8 @@
-use crate::{err, error};
+use crate::{err, error, helpers::WrappedStruct};
 use magnus::{Error, TypedData, Value};
-use wasmtime::{Extern, ExternRef, Val, ValType};
+use wasmtime::{ExternRef, Val, ValType};
 
-use super::{func::Func, memory::Memory};
+use super::{func::Func, memory::Memory, store::Store};
 
 pub trait ToRubyValue {
     fn to_ruby_value(&self) -> Result<Value, Error>;
@@ -79,18 +79,9 @@ impl ToExtern for Value {
     }
 }
 
-pub trait WrapWasmtimeType {
-    fn wrap_wasmtime_type(&self, store: Value) -> Result<Value, Error>;
-}
-
-impl WrapWasmtimeType for Extern {
-    fn wrap_wasmtime_type(&self, store: Value) -> Result<Value, Error> {
-        match self {
-            Extern::Func(func) => Ok(Func::from_inner(store, *func).into()),
-            Extern::Memory(mem) => Ok(Memory::from_inner(store, *mem).into()),
-            Extern::Global(_) => err!("global not yet supported"),
-            Extern::Table(_) => err!("table not yet supported"),
-            Extern::SharedMemory(_) => err!("shared memory not supported"),
-        }
-    }
+pub trait WrapWasmtimeType<T>
+where
+    T: TypedData,
+{
+    fn wrap_wasmtime_type(&self, store: WrappedStruct<Store>) -> Result<T, Error>;
 }

--- a/ext/src/ruby_api/errors.rs
+++ b/ext/src/ruby_api/errors.rs
@@ -1,9 +1,17 @@
 use crate::ruby_api::root;
+use magnus::rb_sys::value_from_raw;
 use magnus::{exception::standard_error, memoize, ExceptionClass, Module};
 
 /// Base error class for all Wasmtime errors.
 pub fn base_error() -> ExceptionClass {
     *memoize!(ExceptionClass: root().define_error("Error", standard_error()).unwrap())
+}
+
+/// Ruby's `NotImplementedError` class.
+pub fn not_implemented_error() -> ExceptionClass {
+    *memoize!(ExceptionClass: {
+        value_from_raw(rb_sys::rb_eNotImpError).try_convert().unwrap()
+    })
 }
 
 #[macro_export]
@@ -17,5 +25,12 @@ macro_rules! err {
 macro_rules! error {
     ($($arg:expr),*) => {
         Error::new($crate::ruby_api::errors::base_error(), format!($($arg),*))
+    };
+}
+
+#[macro_export]
+macro_rules! not_implemented {
+    ($($arg:expr),*) => {
+        Err(Error::new($crate::ruby_api::errors::not_implemented_error(), format!($($arg),*)))
     };
 }

--- a/ext/src/ruby_api/errors.rs
+++ b/ext/src/ruby_api/errors.rs
@@ -1,5 +1,6 @@
 use crate::ruby_api::root;
 use magnus::rb_sys::value_from_raw;
+use magnus::Error;
 use magnus::{exception::standard_error, memoize, ExceptionClass, Module};
 
 /// Base error class for all Wasmtime errors.
@@ -12,6 +13,11 @@ pub fn not_implemented_error() -> ExceptionClass {
     *memoize!(ExceptionClass: {
         value_from_raw(rb_sys::rb_eNotImpError).try_convert().unwrap()
     })
+}
+
+/// The `Wasmtime::ConversionError` class.
+pub fn conversion_error() -> ExceptionClass {
+    *memoize!(ExceptionClass: root().define_error("ConversionError", base_error()).unwrap())
 }
 
 #[macro_export]
@@ -33,4 +39,18 @@ macro_rules! not_implemented {
     ($($arg:expr),*) => {
         Err(Error::new($crate::ruby_api::errors::not_implemented_error(), format!($($arg),*)))
     };
+}
+
+#[macro_export]
+macro_rules! conversion_err {
+    ($($arg:expr),*) => {
+        Err(Error::new($crate::ruby_api::errors::conversion_error(), format!("cannot convert {} to {}", $($arg),*)))
+    };
+}
+
+pub fn init() -> Result<(), Error> {
+    let _ = base_error();
+    let _ = conversion_error();
+
+    Ok(())
 }

--- a/ext/src/ruby_api/externals.rs
+++ b/ext/src/ruby_api/externals.rs
@@ -1,0 +1,78 @@
+use lazy_static::__Deref;
+use magnus::{method, DataTypeFunctions, Error, Module, RClass, TypedData, Value};
+
+use crate::{err, helpers::WrappedStruct, not_implemented};
+
+use super::{convert::WrapWasmtimeType, func::Func, memory::Memory, root, store::Store};
+
+#[derive(TypedData)]
+#[magnus(class = "Wasmtime::Extern", mark, free_immediatly)]
+pub enum Extern {
+    Func(WrappedStruct<Func>),
+    Memory(WrappedStruct<Memory>),
+}
+
+impl DataTypeFunctions for Extern {
+    fn mark(&self) {
+        match self {
+            Extern::Func(f) => f.mark(),
+            Extern::Memory(m) => m.mark(),
+        }
+    }
+}
+
+impl Extern {
+    pub fn to_func(rb_self: WrappedStruct<Self>) -> Result<Value, Error> {
+        match rb_self.get()? {
+            Extern::Func(f) => Ok(*f.deref()),
+            _ => err!("{} is not a function", rb_self.deref().inspect()),
+        }
+    }
+
+    pub fn to_memory(rb_self: WrappedStruct<Self>) -> Result<Value, Error> {
+        match rb_self.get()? {
+            Extern::Memory(f) => Ok(*f.deref()),
+            _ => err!("{} is not a memory", rb_self.deref().inspect()),
+        }
+    }
+
+    pub fn to_global(_rb_self: WrappedStruct<Self>) -> Result<Value, Error> {
+        not_implemented!("Extern#to_global")
+    }
+
+    pub fn to_table(_rb_self: WrappedStruct<Self>) -> Result<Value, Error> {
+        not_implemented!("Extern#to_table")
+    }
+
+    pub fn to_shared_memory(_rb_self: WrappedStruct<Self>) -> Result<Value, Error> {
+        not_implemented!("Extern#to_shared_memory")
+    }
+}
+
+impl WrapWasmtimeType<Extern> for wasmtime::Extern {
+    fn wrap_wasmtime_type(&self, store: WrappedStruct<Store>) -> Result<Extern, Error> {
+        match self {
+            wasmtime::Extern::Func(func) => Ok(Extern::Func(Func::from_inner(store, *func).into())),
+            wasmtime::Extern::Memory(mem) => {
+                Ok(Extern::Memory(Memory::from_inner(store, *mem).into()))
+            }
+            wasmtime::Extern::Global(_) => err!("global not yet supported"),
+            wasmtime::Extern::Table(_) => err!("table not yet supported"),
+            wasmtime::Extern::SharedMemory(_) => err!("shared memory not supported"),
+        }
+    }
+}
+
+pub fn init() -> Result<(), Error> {
+    let class = root().define_class("Extern", Default::default())?;
+
+    class.define_method("to_func", method!(Extern::to_func, 0))?;
+    class.define_method("to_memory", method!(Extern::to_memory, 0))?;
+    class.define_method("to_global", method!(Extern::to_global, 0))?;
+    class.define_method("to_table", method!(Extern::to_table, 0))?;
+    class.define_method("to_shared_memory", method!(Extern::to_shared_memory, 0))?;
+
+    Ok(())
+}
+
+unsafe impl Send for Extern {}

--- a/ext/src/ruby_api/func.rs
+++ b/ext/src/ruby_api/func.rs
@@ -7,9 +7,9 @@ use super::{
 };
 use crate::{error, helpers::WrappedStruct};
 use magnus::{
-    block::Proc, function, memoize, method, r_typed_data::DataTypeBuilder,
-    scan_args::scan_args, value::BoxValue, DataTypeFunctions, Error, Exception, Module as _,
-    Object, RArray, RClass, RHash, RString, TryConvert, TypedData, Value, QNIL,
+    block::Proc, function, memoize, method, r_typed_data::DataTypeBuilder, scan_args::scan_args,
+    value::BoxValue, DataTypeFunctions, Error, Exception, Module as _, Object, RArray, RClass,
+    RHash, RString, TryConvert, TypedData, Value, QNIL,
 };
 use std::cell::RefCell;
 use wasmtime::{

--- a/ext/src/ruby_api/linker.rs
+++ b/ext/src/ruby_api/linker.rs
@@ -105,18 +105,6 @@ impl Linker {
         }
     }
 
-    pub fn get_func(
-        &self,
-        s: WrappedStruct<Store>,
-        module: RString,
-        name: RString,
-    ) -> Result<Option<WrappedStruct<Func>>, Error> {
-        match self.get(s, module, name)? {
-            Some(Extern::Func(f)) => Ok(Some(f)),
-            _ => Ok(None),
-        }
-    }
-
     pub fn instance(
         &self,
         store: &Store,
@@ -214,7 +202,6 @@ pub fn init() -> Result<(), Error> {
     class.define_method("define", method!(Linker::define, 3))?;
     class.define_method("func_new", method!(Linker::func_new, -1))?;
     class.define_method("get", method!(Linker::get, 3))?;
-    class.define_method("get_func", method!(Linker::get_func, 3))?;
     class.define_method("instance", method!(Linker::instance, 3))?;
     class.define_method("module", method!(Linker::module, 3))?;
     class.define_method("alias", method!(Linker::alias, 4))?;

--- a/ext/src/ruby_api/memory.rs
+++ b/ext/src/ruby_api/memory.rs
@@ -1,28 +1,28 @@
 use super::{memory_type::MemoryType, root, store::Store};
-use crate::error;
+use crate::{error, helpers::WrappedStruct};
 use magnus::{
-    function, gc, method, r_string::RString, DataTypeFunctions, Error, Module as _, Object,
-    TypedData, Value,
+    function, method, r_string::RString, DataTypeFunctions, Error, Module as _, Object,
+    TypedData,
 };
 use wasmtime::{Extern, Memory as MemoryImpl};
 
 #[derive(TypedData, Debug)]
 #[magnus(class = "Wasmtime::Memory", mark, size, free_immediatly)]
 pub struct Memory {
-    store: Value,
+    store: WrappedStruct<Store>,
     inner: MemoryImpl,
 }
 
 impl DataTypeFunctions for Memory {
     fn mark(&self) {
-        gc::mark(&self.store);
+        self.store.mark()
     }
 }
 unsafe impl Send for Memory {}
 
 impl Memory {
-    pub fn new(s: Value, memtype: &MemoryType) -> Result<Self, Error> {
-        let store: &Store = s.try_convert()?;
+    pub fn new(s: WrappedStruct<Store>, memtype: &MemoryType) -> Result<Self, Error> {
+        let store = s.get()?;
 
         let inner = MemoryImpl::new(store.context_mut(), memtype.get().clone())
             .map_err(|e| error!("{}", e))?;
@@ -30,7 +30,7 @@ impl Memory {
         Ok(Self { store: s, inner })
     }
 
-    pub fn from_inner(store: Value, inner: MemoryImpl) -> Self {
+    pub fn from_inner(store: WrappedStruct<Store>, inner: MemoryImpl) -> Self {
         Self { store, inner }
     }
 

--- a/ext/src/ruby_api/memory.rs
+++ b/ext/src/ruby_api/memory.rs
@@ -1,8 +1,7 @@
 use super::{memory_type::MemoryType, root, store::Store};
 use crate::{error, helpers::WrappedStruct};
 use magnus::{
-    function, method, r_string::RString, DataTypeFunctions, Error, Module as _, Object,
-    TypedData,
+    function, method, r_string::RString, DataTypeFunctions, Error, Module as _, Object, TypedData,
 };
 use wasmtime::{Extern, Memory as MemoryImpl};
 

--- a/ext/src/ruby_api/mod.rs
+++ b/ext/src/ruby_api/mod.rs
@@ -4,6 +4,7 @@ mod config;
 mod convert;
 mod engine;
 mod errors;
+mod externals;
 mod func;
 mod func_type;
 mod instance;
@@ -32,5 +33,6 @@ pub fn init() -> Result<(), Error> {
     memory_type::init()?;
     memory::init()?;
     linker::init()?;
+    externals::init()?;
     Ok(())
 }

--- a/ext/src/ruby_api/mod.rs
+++ b/ext/src/ruby_api/mod.rs
@@ -23,6 +23,9 @@ pub fn root() -> RModule {
 }
 
 pub fn init() -> Result<(), Error> {
+    let _ = root();
+
+    errors::init()?;
     config::init()?;
     engine::init()?;
     module::init()?;
@@ -34,5 +37,6 @@ pub fn init() -> Result<(), Error> {
     memory::init()?;
     linker::init()?;
     externals::init()?;
+
     Ok(())
 }

--- a/ext/src/ruby_api/store.rs
+++ b/ext/src/ruby_api/store.rs
@@ -39,7 +39,7 @@ impl StoreData {
     }
 }
 
-#[derive(TypedData)]
+#[derive(Debug, TypedData)]
 #[magnus(class = "Wasmtime::Store", size, mark, free_immediatly)]
 pub struct Store {
     inner: UnsafeCell<StoreImpl<StoreData>>,

--- a/spec/unit/extern_spec.rb
+++ b/spec/unit/extern_spec.rb
@@ -7,12 +7,21 @@ module Wasmtime
       m: [:to_memory, Memory]
     }
 
-    describe "#ty" do
-      cases.each do |name, (meth, klass)|
-        it "exposes the #{name.inspect} export with #{klass.inspect} type" do
+    cases.each do |name, (meth, klass)|
+      describe "##{meth}" do
+        it "returns an instance of #{klass}" do
           extern_mod = new_extern_module
+
           expect(extern_mod.exports[name.to_s].public_send(meth)).to be_instance_of(klass)
         end
+      end
+    end
+
+    describe "#inspect" do
+      it "looks pretty" do
+        result = new_extern_module.exports["f"].inspect
+
+        expect(result).to match(/\A#<Wasmtime::Extern:0x\h{16} @value=#<Wasmtime::Func:0x\h{16}>>$/)
       end
     end
 

--- a/spec/unit/extern_spec.rb
+++ b/spec/unit/extern_spec.rb
@@ -11,8 +11,19 @@ module Wasmtime
       describe "##{meth}" do
         it "returns an instance of #{klass}" do
           extern_mod = new_extern_module
+          export = extern_mod.exports[name.to_s]
 
-          expect(extern_mod.exports[name.to_s].public_send(meth)).to be_instance_of(klass)
+          expect(export.public_send(meth)).to be_instance_of(klass)
+        end
+
+        it "raises an error when extern is not a #{klass}" do
+          extern_mod = new_extern_module
+          invalid_methods = cases.flat_map { |_, (meth, _)| meth } - [meth]
+
+          invalid_methods.each do |invalid_method|
+            export = extern_mod.exports[name.to_s]
+            expect { export.public_send(invalid_method) }.to raise_error(Wasmtime::ConversionError)
+          end
         end
       end
     end

--- a/spec/unit/extern_spec.rb
+++ b/spec/unit/extern_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+module Wasmtime
+  RSpec.describe Extern do
+    cases = {
+      f: [:to_func, Func],
+      m: [:to_memory, Memory]
+    }
+
+    describe "#ty" do
+      cases.each do |name, (meth, klass)|
+        it "exposes the #{name.inspect} export with #{klass.inspect} type" do
+          extern_mod = new_extern_module
+          expect(extern_mod.exports[name.to_s].public_send(meth)).to be_instance_of(klass)
+        end
+      end
+    end
+
+    def new_extern_module
+      compile <<~WAT
+        (module
+          (func (export "f"))
+          (memory (export "m") 1)
+        )
+      WAT
+    end
+  end
+end

--- a/spec/unit/instance_spec.rb
+++ b/spec/unit/instance_spec.rb
@@ -30,7 +30,9 @@ module Wasmtime
         )
       WAT
 
-      expect(instance.exports).to include("hello" => be_a(Func), "mem" => be_a(Memory))
+      expect(instance.exports).to include("hello" => be_a(Extern), "mem" => be_a(Extern))
+      expect(instance.exports["hello"].to_func).to be_a(Func)
+      expect(instance.exports["mem"].to_memory).to be_a(Memory)
     end
 
     it "exposes export" do
@@ -38,7 +40,7 @@ module Wasmtime
         (module
           (func (export "f")))
       WAT
-      expect(instance.export("f")).to be_a(Func)
+      expect(instance.export("f").to_func).to be_a(Func)
     end
 
     describe "invoke" do

--- a/spec/unit/linker_spec.rb
+++ b/spec/unit/linker_spec.rb
@@ -45,7 +45,7 @@ module Wasmtime
       store = Store.new(engine)
       memory = Memory.new(store, MemoryType.new(1))
       linker.define("mod", "mem", memory)
-      expect(linker.get(store, "mod", "mem")).to be_instance_of(Memory)
+      expect(linker.get(store, "mod", "mem").to_memory).to be_instance_of(Memory)
     end
 
     it "define func" do
@@ -53,7 +53,7 @@ module Wasmtime
       store = Store.new(engine)
       func = Func.new(store, FuncType.new([], [])) {}
       linker.define("mod", "fn", func)
-      expect(linker.get(store, "mod", "fn")).to be_instance_of(Func)
+      expect(linker.get(store, "mod", "fn").to_func).to be_instance_of(Func)
     end
 
     it "func_new accepts block" do
@@ -74,7 +74,7 @@ module Wasmtime
         calls += 1
         expect(caller).to be_instance_of(Caller)
       end
-      func = linker.get(Store.new(engine), "", "")
+      func = linker.get(Store.new(engine), "", "").to_func
       expect { func.call }.to change { calls }.by(1)
     end
 
@@ -87,7 +87,7 @@ module Wasmtime
     it "get can return Func" do
       linker = new_linker
       linker.func_new("mod", "fn", FuncType.new([], [:i32])) { 42 }
-      func = linker.get(Store.new(engine), "mod", "fn")
+      func = linker.get(Store.new(engine), "mod", "fn").to_func
       expect(func).to be_instance_of(Func)
       expect(func.call).to eq(42)
     end


### PR DESCRIPTION
Previously, `Extern` was implicitly mapped to the underlying variant. For example, a `Extern::Func` would automatically become `Wasmtime::Func` when loading the extern in Ruby. This differs from `Wasmtime`, where the caller must do the conversion to ensure the export they want is valid.

To accomplish this, I added a `WrappedStruct<T>` helper to codify a bunch of the conversions we were doing previously. This cleans thing up nicely, so [I made a proposal to `magnus` for it](https://github.com/matsadler/magnus/issues/28) as well.