### PR TITLE
Add new `mem:check` task to run Valgrind in CI

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Run "mem:check" task
         env:
           RSPEC_FORMATTER: "progress"
+          RSPEC_FAILURE_EXIT_CODE: "0"
         run: |
           if ! bundle exec rake mem:check; then
             echo "::error::Valgrind memory check failed, for more info please see ./suppressions/readme.md"

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -1,0 +1,48 @@
+---
+name: Memcheck
+
+on:
+  workflow_dispatch:
+    inputs:
+      ruby-version:
+        description: 'Ruby version to memcheck'
+        required: true
+        default: '3.1'
+        type: choice
+        options:
+          - 'head'
+          - '3.1'
+          - '3.0'
+          - '2.7'
+  push:
+
+jobs:
+  memcheck:
+    name: Memcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@main
+        with:
+          ruby-version: ${{ inputs.ruby-version || '3.1' }}
+          bundler-cache: true
+          cargo-cache: true
+          cache-version: v1
+
+      - name: Install deps
+        run: |
+          bundle config unset deployment
+          bundle add ruby_memcheck & # avoid usage in Gemfile bc it pulls in nokogiri
+          sudo apt install -y valgrind &
+          wait
+          bundle config set deployment true
+
+      - name: Run "mem:check" task
+        env:
+          RSPEC_FORMATTER: "progress"
+        run: |
+          if ! bundle exec rake mem:check; then
+            echo "::error::Valgrind memory check failed, for more info please see ./suppressions/readme.md"
+            exit 1
+          fi

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
---format documentation
 --color
 --require spec_helper

--- a/rakelib/mem.rake
+++ b/rakelib/mem.rake
@@ -57,4 +57,23 @@ namespace :mem do
       end
     end
   end
+
+  if RbConfig::CONFIG["host_os"] == "linux"
+    begin
+      require "ruby_memcheck"
+      require "ruby_memcheck/rspec/rake_task"
+
+      RubyMemcheck.config(binary_name: "ext")
+
+      RubyMemcheck::RSpec::RakeTask.new(check: :compile)
+    rescue LoadError
+      task :check do
+        abort 'Please add `gem "ruby_memcheck"` to your Gemfile to use the "mem:check" task'
+      end
+    end
+  else
+    task :check do
+      abort 'The "mem:check" task is only available on Linux'
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,8 @@ RSpec.configure do |config|
 
   config.include_context("default lets")
 
+  config.default_formatter = ENV.fetch("RSPEC_FORMATTER", "doc")
+
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 
@@ -43,3 +45,5 @@ RSpec.configure do |config|
     end
   end
 end
+
+at_exit { GC.start(full_mark: true) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,10 +24,12 @@ RSpec.configure do |config|
 
   config.include_context("default lets")
 
+  # So memcheck steps can still pass if RSpec fails
+  config.failure_exit_code = ENV.fetch("RSPEC_FAILURE_EXIT_CODE", 1).to_i
   config.default_formatter = ENV.fetch("RSPEC_FORMATTER", "doc")
 
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = ".rspec_status" unless ENV["CI"]
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!

--- a/suppressions/readme.md
+++ b/suppressions/readme.md
@@ -1,0 +1,7 @@
+# Suppressions
+
+This folder includes Valgrind suppressions used by the
+[`ruby_memcheck`][ruby_memcheck] gem. If you the `memcheck` CI job fails, you
+may need to add a suppression to `ruby-3.1.supp` to fix it.
+
+[ruby_memcheck]: https://github.com/Shopify/ruby_memcheck

--- a/suppressions/ruby-3.1.supp
+++ b/suppressions/ruby-3.1.supp
@@ -1,0 +1,23 @@
+{
+  Rust probes for statx(buf)
+  Memcheck:Param
+  statx(buf)
+  ...
+  fun:*try_statx*
+  ...
+}
+{
+  Rust probes for statx(file_name)
+  Memcheck:Param
+  statx(file_name)
+  ...
+  fun:*try_statx*
+  ...
+}
+{
+  Valgrind is detecting a "Invalid read of size 8" during this process, not sure why
+  Memcheck:Addr8
+  fun:each_location.constprop.1
+  fun:gc_mark_children
+  ...
+}


### PR DESCRIPTION
This PR integrates the great [`ruby_memcheck`](https://github.com/Shopify/ruby_memcheck) gem into the repo. It's super powerful... I immediately [found a memory leak in magnus](https://github.com/matsadler/magnus/pull/30) and was able to fix it. 

As of this PR, there are no leaks detected, so we should be good to integrate into CI. One question I have is: Should we run it on every PR, or no? I'm thinking that might be too much, but we should at least run it on `main`. Thoughts?