### PR TITLE
Register mark objects for some constants

### DIFF
--- a/ext/src/ruby_api/errors.rs
+++ b/ext/src/ruby_api/errors.rs
@@ -1,9 +1,15 @@
 use crate::ruby_api::root;
-use magnus::{exception::standard_error, memoize, ExceptionClass, Module};
+use magnus::{
+    exception::standard_error, gc::register_mark_object, memoize, ExceptionClass, Module,
+};
 
 /// Base error class for all Wasmtime errors.
 pub fn base_error() -> ExceptionClass {
-    *memoize!(ExceptionClass: root().define_error("Error", standard_error()).unwrap())
+    *memoize!(ExceptionClass: {
+        let exc = root().define_error("Error", standard_error()).unwrap();
+        register_mark_object(exc);
+        exc
+    })
 }
 
 #[macro_export]

--- a/ext/src/ruby_api/mod.rs
+++ b/ext/src/ruby_api/mod.rs
@@ -1,7 +1,11 @@
 #![allow(rustdoc::broken_intra_doc_links)]
 #![allow(rustdoc::invalid_html_tags)]
 #![allow(rustdoc::bare_urls)]
-use magnus::{define_module, memoize, Error, RModule};
+use magnus::{
+    define_module,
+    gc::{register_address},
+    memoize, Error, RModule,
+};
 
 mod config;
 mod convert;
@@ -21,7 +25,11 @@ mod store;
 
 /// The "Wasmtime" Ruby module.
 pub fn root() -> RModule {
-    *memoize!(RModule: define_module("Wasmtime").unwrap())
+    *memoize!(RModule: {
+        let root = define_module("Wasmtime").unwrap();
+        register_address(&*root);
+        root
+    })
 }
 
 pub fn init() -> Result<(), Error> {


### PR DESCRIPTION
Small PR to ensure that `Wasmtime` and `Wasmtime::Error` constants are never move (even if they are somehow defined in Ruby).