### PR TITLE
Improve the docs after #14

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem "get_process_mem"
   gem "ruby-lsp", require: false
   gem "yard", require: false
-  gem "yard-rustdoc", "~> 0.1", require: false
+  gem "yard-rustdoc", "~> 0.2", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ GEM
     webrick (1.7.0)
     yard (0.9.28)
       webrick (~> 1.7.0)
-    yard-rustdoc (0.1.0)
+    yard-rustdoc (0.2.0)
       syntax_tree (~> 4.0)
       yard (~> 0.9)
 
@@ -92,7 +92,7 @@ DEPENDENCIES
   standard (~> 1.17)
   wasmtime-rb!
   yard
-  yard-rustdoc (~> 0.1)
+  yard-rustdoc (~> 0.2)
 
 BUNDLED WITH
    2.3.24

--- a/ext/src/ruby_api/externals.rs
+++ b/ext/src/ruby_api/externals.rs
@@ -5,7 +5,7 @@ use magnus::{
 };
 
 /// @yard
-/// An external item to a WebAssembly module, or a list of what can possibly be exported from a wasm module.
+/// An external item to a WebAssembly module, or a list of what can possibly be exported from a Wasm module.
 /// @see https://docs.rs/wasmtime/latest/wasmtime/enum.Extern.html Wasmtime's Rust doc
 #[derive(TypedData)]
 #[magnus(class = "Wasmtime::Extern", size, mark, free_immediatly)]
@@ -25,7 +25,9 @@ impl DataTypeFunctions for Extern {
 
 impl Extern {
     /// @yard
-    /// @return [Wasmtime::Func] The exported function, if this is a function.
+    /// Returns the exported function or raises a `{ConversionError}` when the export is not a
+    /// function.
+    /// @return [Func] The exported function.
     pub fn to_func(rb_self: WrappedStruct<Self>) -> Result<Value, Error> {
         match rb_self.get()? {
             Extern::Func(f) => Ok(f.to_value()),
@@ -34,7 +36,9 @@ impl Extern {
     }
 
     /// @yard
-    /// @return [Wasmtime::Memory] The exported memory, if this is a memory.
+    /// Returns the exported memory or raises a `{ConversionError}` when the export is not a
+    /// memory.
+    /// @return [Memory] The exported memory.
     pub fn to_memory(rb_self: WrappedStruct<Self>) -> Result<Value, Error> {
         match rb_self.get()? {
             Extern::Memory(f) => Ok(f.to_value()),

--- a/ext/src/ruby_api/instance.rs
+++ b/ext/src/ruby_api/instance.rs
@@ -88,10 +88,11 @@ impl Instance {
     }
 
     /// @yard
-    /// Returns a Hash of exports where keys are the export name (String).
+    /// Returns a +Hash+ of exports where keys are export names as +String+s
+    /// and values are {Extern}s.
     ///
     /// @def exports
-    /// @return [Hash{String => Func, Memory}]
+    /// @return [Hash{String => Extern}]
     pub fn exports(&self) -> Result<RHash, Error> {
         let store = self.store.get()?;
         let mut ctx = store.context_mut();
@@ -112,7 +113,7 @@ impl Instance {
     ///
     /// @def export(name)
     /// @param name [String]
-    /// @return [Func, Memory, nil] The export if it exists, nil otherwise.
+    /// @return [Extern, nil] The export if it exists, nil otherwise.
     pub fn export(&self, str: RString) -> Result<Option<super::externals::Extern>, Error> {
         let store = self.store.get()?;
         let export = self

--- a/ext/src/ruby_api/linker.rs
+++ b/ext/src/ruby_api/linker.rs
@@ -129,7 +129,7 @@ impl Linker {
     /// @param store [Store]
     /// @param mod [String] Module name
     /// @param name [String] Import name
-    /// @return [Func, Memory, nil] The item if it exists, nil otherwise.
+    /// @return [Extern, nil] The item if it exists, nil otherwise.
     pub fn get(
         &self,
         s: WrappedStruct<Store>,

--- a/lib/wasmtime.rb
+++ b/lib/wasmtime.rb
@@ -12,5 +12,6 @@ end
 
 module Wasmtime
   class Error < StandardError; end
-  # Your code goes here...
+
+  class ConversionError < Error; end
 end


### PR DESCRIPTION
- Bump yard-rustdoc for correctly tagging `rb_self` as instance methods and allowing docs on `Enum`.
- Define `ConversionError` in Ruby so that YARD can see it. yard-rustdoc does not support inheritance nor declaring classes without a Struct / Enum, so defining it in Ruby was much easier than changing yard-rustdoc to support this.
- Update the documentation for Extern after #14