### PR TITLE
Publish documentation automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Lint rust
         run: cargo clippy -- -D warnings && cargo fmt --check
 
-  doc:
+  build_doc:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -70,3 +70,10 @@ jobs:
 
       - name: Generate doc
         run: bundle exec rake doc
+
+      - name: Upload generated doc
+        uses: actions/upload-artifact@v3
+        with:
+          name: doc
+          path: doc
+          retention-days: 1

--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -1,0 +1,79 @@
+---
+name: Publish doc
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+    branches:
+      - main
+    tags:
+      - v*
+
+jobs:
+  publish_doc:
+    runs-on: ubuntu-latest
+    needs: build_doc
+    steps:
+      - name: "Check CI success"
+        if: ${{ github.event.workflow_run.conclusion != 'success' }}
+        run: exit 1
+
+      - uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+
+      - name: Download docs
+        uses: actions/download-artifact@v3
+        with:
+          name: doc
+          path: doc
+
+      - name: Current doc dir
+        id: doc-dir
+        uses: k1LoW/github-script-ruby@v1
+        with:
+          result-encoding: string
+          script: |
+            context.ref
+              .gsub(%r{\Arefs/heads/}, "")
+              .gsub(%r{\Arefs/tags/}, "")
+
+      - name: Move docs to dest folder
+        run: |
+          ls -lah
+          rm -rf ${{steps.doc-dir.outputs.result}}
+          mv doc ${{steps.doc-dir.outputs.result}}
+
+      - name: Find the latest doc
+        uses: k1LoW/github-script-ruby@v1
+        id: latest-dir
+        with:
+          result-encoding: string
+          script: |
+            build_version = -> (str) do
+              Gem::Version.new(str.gsub(/\Av/, ""))
+            rescue nil
+            end
+
+            Dir
+              .glob('v*')
+              .select { File.directory?(_1) && build_version[_1] }
+              .max_by(&build_version)
+              &.to_s || "main"
+
+      - name: Commit the changes
+        run: |
+          ln -sf ${{steps.latest-dir.outputs.result}} latest
+          git add ${{steps.doc-dir.outputs.result}} latest
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git commit -m "Bump doc"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages


### PR DESCRIPTION
Automate publishing docs for `main` and `v*` tags. It does the following:
- Saves the doc built from CI as an artifact
- Commits the doc to the `gh-pages` in a new folder, either `main` or a folder for the current tag.
- Creates a `latest` symlink to the last found version, which includes pre-release. Last here is determined using RubyGem's version comparable.
  Once we have a stable release, we could also create another symlink for `stable` (or replace `latest` altogether).

Currently, YARD does not mention which version you're browsing which is annoying (especially with `/latest` in your URL bar). But I'm sure that something we can add later, YARD is very extensible.


I got the script to work using a single workflow ([see this run](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/3481091387/jobs/5821800355)), but decided to split it in 2 workflows so that CI stays focused on... well CI. In order to validate that the split indeed works, I need to get this on main. [From GitHub's doc](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run:~:text=GitHub%20Actions.%22-,Note%3A%20This%20event%20will%20only%20trigger%20a%20workflow%20run%20if%20the%20workflow%20file%20is%20on%20the%20default%20branch.,-Note%3A%20You):

> Note: This event will only trigger a workflow run if the workflow file is on the default branch.