### PR TITLE
Implement Trap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,7 @@ dependencies = [
 name = "ext"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "lazy_static",
  "magnus",
  "rb-sys",

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -14,3 +14,4 @@ lazy_static = "1.4.0"
 magnus = { git = "https://github.com/matsadler/magnus", features = ["rb-sys-interop"] }
 rb-sys = "~0.9.38"
 wasmtime = "2.0.2"
+anyhow = "*" # Use whatever Wasmtime uses

--- a/ext/src/helpers/wrapped_struct.rs
+++ b/ext/src/helpers/wrapped_struct.rs
@@ -18,6 +18,7 @@ impl<T: TypedData> Clone for WrappedStruct<T> {
         }
     }
 }
+impl<T: TypedData> Copy for WrappedStruct<T> {}
 
 impl<T: TypedData> WrappedStruct<T> {
     /// Gets the underlying struct.
@@ -26,7 +27,7 @@ impl<T: TypedData> WrappedStruct<T> {
     }
 
     /// Get the Ruby [`Value`] for this struct.
-    pub fn to_value(&self) -> Value {
+    pub fn to_value(self) -> Value {
         self.inner.into()
     }
 

--- a/ext/src/ruby_api/func.rs
+++ b/ext/src/ruby_api/func.rs
@@ -139,14 +139,7 @@ impl<'a> Func<'a> {
         let mut results = vec![Val::null(); func_ty.results().len()];
 
         func.call(store.context_mut()?, &params, &mut results)
-            .map_err(|e| {
-                store
-                    .context_mut()
-                    .expect("store context is still reachable")
-                    .data_mut()
-                    .take_last_error()
-                    .unwrap_or_else(|| error!("Could not invoke function: {}", e))
-            })?;
+            .map_err(|e| store.handle_wasm_error(e))?;
 
         match results.as_slice() {
             [] => Ok(QNIL.into()),

--- a/ext/src/ruby_api/instance.rs
+++ b/ext/src/ruby_api/instance.rs
@@ -66,7 +66,7 @@ impl Instance {
 
         let module = module.get();
         let inner = InstanceImpl::new(context, module, &imports)
-            .map_err(|e| StoreContextValue::from(wrapped_store.clone()).handle_wasm_error(e))?;
+            .map_err(|e| StoreContextValue::from(wrapped_store).handle_wasm_error(e))?;
 
         Ok(Self {
             inner,
@@ -95,7 +95,7 @@ impl Instance {
 
         for export in self.inner.exports(&mut ctx) {
             let export_name: RString = export.name().into();
-            let wrapped_store = self.store.clone();
+            let wrapped_store = self.store;
             let wrapped_export = export
                 .into_extern()
                 .wrap_wasmtime_type(wrapped_store.into())?;
@@ -117,9 +117,7 @@ impl Instance {
             .inner
             .get_export(store.context_mut(), unsafe { str.as_str()? });
         match export {
-            Some(export) => export
-                .wrap_wasmtime_type(self.store.clone().into())
-                .map(Some),
+            Some(export) => export.wrap_wasmtime_type(self.store.into()).map(Some),
             None => Ok(None),
         }
     }
@@ -146,7 +144,7 @@ impl Instance {
 
         let store: &Store = self.store.try_convert()?;
         let func = self.get_func(store.context_mut(), unsafe { name.as_str()? })?;
-        Func::invoke(&self.store.clone().into(), &func, &args[1..]).map_err(|e| e.into())
+        Func::invoke(&self.store.into(), &func, &args[1..]).map_err(|e| e.into())
     }
 
     fn get_func(

--- a/ext/src/ruby_api/instance.rs
+++ b/ext/src/ruby_api/instance.rs
@@ -3,9 +3,9 @@ use super::{
     func::Func,
     module::Module,
     root,
-    store::{Store, StoreData},
+    store::{Store, StoreContextValue, StoreData},
 };
-use crate::{err, error, helpers::WrappedStruct};
+use crate::{err, helpers::WrappedStruct};
 use magnus::{
     function, method, scan_args, DataTypeFunctions, Error, Module as _, Object, RArray, RHash,
     RString, TypedData, Value,
@@ -65,13 +65,8 @@ impl Instance {
         };
 
         let module = module.get();
-        let inner = InstanceImpl::new(context, module, &imports).map_err(|e| {
-            store
-                .context_mut()
-                .data_mut()
-                .take_last_error()
-                .unwrap_or_else(|| error!("{}", e))
-        })?;
+        let inner = InstanceImpl::new(context, module, &imports)
+            .map_err(|e| StoreContextValue::from(wrapped_store.clone()).handle_wasm_error(e))?;
 
         Ok(Self {
             inner,

--- a/ext/src/ruby_api/linker.rs
+++ b/ext/src/ruby_api/linker.rs
@@ -7,7 +7,7 @@ use super::{
     instance::Instance,
     module::Module,
     root,
-    store::{Store, StoreData},
+    store::{Store, StoreContextValue, StoreData},
 };
 use crate::{error, helpers::WrappedStruct, ruby_api::convert::ToExtern};
 use magnus::{
@@ -246,13 +246,7 @@ impl Linker {
         self.inner
             .borrow_mut()
             .instantiate(store.context_mut(), module.get())
-            .map_err(|e| {
-                store
-                    .context_mut()
-                    .data_mut()
-                    .take_last_error()
-                    .unwrap_or_else(|| error!("{}", e))
-            })
+            .map_err(|e| StoreContextValue::from(wrapped_store.clone()).handle_wasm_error(e))
             .map(|instance| {
                 self.refs.borrow().iter().for_each(|val| store.retain(*val));
                 Instance::from_inner(s, instance)

--- a/ext/src/ruby_api/linker.rs
+++ b/ext/src/ruby_api/linker.rs
@@ -246,7 +246,7 @@ impl Linker {
         self.inner
             .borrow_mut()
             .instantiate(store.context_mut(), module.get())
-            .map_err(|e| StoreContextValue::from(wrapped_store.clone()).handle_wasm_error(e))
+            .map_err(|e| StoreContextValue::from(wrapped_store).handle_wasm_error(e))
             .map(|instance| {
                 self.refs.borrow().iter().for_each(|val| store.retain(*val));
                 Instance::from_inner(s, instance)

--- a/ext/src/ruby_api/mod.rs
+++ b/ext/src/ruby_api/mod.rs
@@ -1,6 +1,7 @@
 #![allow(rustdoc::broken_intra_doc_links)]
 #![allow(rustdoc::invalid_html_tags)]
 #![allow(rustdoc::bare_urls)]
+#![allow(rustdoc::invalid_rust_codeblocks)]
 use magnus::{define_module, memoize, Error, RModule};
 
 mod config;
@@ -19,6 +20,7 @@ mod module;
 mod params;
 mod static_id;
 mod store;
+mod trap;
 
 /// The "Wasmtime" Ruby module.
 pub fn root() -> RModule {
@@ -29,6 +31,7 @@ pub fn init() -> Result<(), Error> {
     let _ = root();
 
     errors::init()?;
+    trap::init()?;
     config::init()?;
     engine::init()?;
     module::init()?;

--- a/ext/src/ruby_api/store.rs
+++ b/ext/src/ruby_api/store.rs
@@ -1,6 +1,5 @@
-use crate::helpers::WrappedStruct;
-
 use super::{engine::Engine, func::Caller, root};
+use crate::{error, helpers::WrappedStruct};
 use magnus::{
     exception::Exception, function, method, scan_args, value::BoxValue, DataTypeFunctions, Error,
     Module, Object, TypedData, Value, QNIL,
@@ -157,6 +156,16 @@ impl<'a> StoreContextValue<'a> {
         match self {
             Self::Store(store) => Ok(store.get()?.context_mut()),
             Self::Caller(caller) => caller.get()?.context_mut(),
+        }
+    }
+
+    pub fn handle_wasm_error(&self, error: anyhow::Error) -> Error {
+        match self.context_mut() {
+            Ok(mut context) => context
+                .data_mut()
+                .take_last_error()
+                .unwrap_or_else(|| error!("{}", error)),
+            Err(e) => e,
         }
     }
 }

--- a/ext/src/ruby_api/trap.rs
+++ b/ext/src/ruby_api/trap.rs
@@ -1,0 +1,101 @@
+use crate::helpers::WrappedStruct;
+use crate::ruby_api::{errors::base_error, root};
+use magnus::Error;
+use magnus::{
+    memoize, method, rb_sys::AsRawValue, DataTypeFunctions, ExceptionClass, Module as _, RModule,
+    Symbol, TypedData, Value,
+};
+use wasmtime::TrapCode;
+
+pub fn trap_error() -> ExceptionClass {
+    *memoize!(ExceptionClass: root().define_error("Trap", base_error()).unwrap())
+}
+
+pub fn trap_code() -> RModule {
+    *memoize!(RModule: root().define_module("TrapCode").unwrap())
+}
+
+macro_rules! trap_const {
+    ($trap:ident) => {
+        trap_code().const_get(stringify!($trap)).map(Some)
+    };
+}
+
+#[derive(TypedData, Debug)]
+#[magnus(class = "Wasmtime::Trap", size, free_immediatly)]
+/// @yard
+pub struct Trap {
+    inner: wasmtime::Trap,
+}
+impl DataTypeFunctions for Trap {}
+
+impl Trap {
+    /// @yard
+    /// Returns the message with backtrace. Example message:
+    ///     wasm trap: wasm `unreachable` instruction executed
+    ///     wasm backtrace:
+    ///     0:   0x1a - <unknown>!<wasm function 0>
+    /// @return [String]
+    pub fn message(&self) -> String {
+        self.inner.to_string()
+    }
+
+    /// @yard
+    /// Returns the trap code as a Symbol, possibly nil if the trap did not
+    /// origin from Wasm code. All possible trap codes are defined as constants on {Trap}.
+    /// @return [Symbol, nil]
+    pub fn trap_code(&self) -> Result<Option<Symbol>, Error> {
+        if let Some(code) = self.inner.trap_code() {
+            match code {
+                TrapCode::HeapMisaligned => trap_const!(HEAP_MISALIGNED),
+                TrapCode::TableOutOfBounds => trap_const!(TABLE_OUT_OF_BOUNDS),
+                TrapCode::IndirectCallToNull => trap_const!(INDIRECT_CALL_TO_NULL),
+                TrapCode::BadSignature => trap_const!(BAD_SIGNATURE),
+                TrapCode::IntegerOverflow => trap_const!(INTEGER_OVERFLOW),
+                TrapCode::IntegerDivisionByZero => trap_const!(INTEGER_DIVISION_BY_ZERO),
+                TrapCode::BadConversionToInteger => trap_const!(BAD_CONVERSION_TO_INTEGER),
+                TrapCode::UnreachableCodeReached => trap_const!(UNREACHABLE_CODE_REACHED),
+                TrapCode::Interrupt => trap_const!(INTERRUPT),
+                TrapCode::AlwaysTrapAdapter => trap_const!(ALWAYS_TRAP_ADAPTER),
+                // When adding a trap code here, define a matching constant on Wasmtime::Trap (in Ruby)
+                _ => trap_const!(UNKNOWN),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn inspect(rb_self: WrappedStruct<Self>) -> Result<String, Error> {
+        let rs_self = rb_self.get()?;
+
+        Ok(format!(
+            "#<Wasmtime::Trap:0x{:016x} @trap_code={}>",
+            rb_self.to_value().as_raw(),
+            Value::from(rs_self.trap_code()?).inspect()
+        ))
+    }
+}
+
+impl From<Trap> for Error {
+    fn from(trap: Trap) -> Self {
+        magnus::Value::from(trap)
+            .try_convert::<magnus::Exception>()
+            .unwrap() // Can't fail: Wasmtime::Trap is an Exception
+            .into()
+    }
+}
+
+impl From<wasmtime::Trap> for Trap {
+    fn from(trap: wasmtime::Trap) -> Self {
+        Self { inner: trap }
+    }
+}
+
+pub fn init() -> Result<(), Error> {
+    let class = trap_error();
+    class.define_method("message", method!(Trap::message, 0))?;
+    class.define_method("trap_code", method!(Trap::trap_code, 0))?;
+    class.define_method("inspect", method!(Trap::inspect, 0))?;
+    class.define_alias("to_s", "message")?;
+    Ok(())
+}

--- a/lib/wasmtime.rb
+++ b/lib/wasmtime.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "wasmtime/version"
+require_relative "wasmtime/trap_code"
 
 # Tries to require the extension for the given Ruby version first
 begin
@@ -14,4 +15,6 @@ module Wasmtime
   class Error < StandardError; end
 
   class ConversionError < Error; end
+
+  class Trap < Error; end
 end

--- a/lib/wasmtime/trap_code.rb
+++ b/lib/wasmtime/trap_code.rb
@@ -1,0 +1,16 @@
+module Wasmtime
+  module TrapCode
+    STACK_OVERFLOW = :stack_overflow
+    HEAP_MISALIGNED = :heap_misaligned
+    TABLE_OUT_OF_BOUNDS = :table_out_of_bounds
+    INDIRECT_CALL_TO_NULL = :indirect_call_to_null
+    BAD_SIGNATURE = :bad_signature
+    INTEGER_OVERFLOW = :integer_overflow
+    INTEGER_DIVISION_BY_ZERO = :integer_division_by_zero
+    BAD_CONVERSION_TO_INTEGER = :bad_conversion_to_integer
+    UNREACHABLE_CODE_REACHED = :unreachable_code_reached
+    INTERRUPT = :interrupt
+    ALWAYS_TRAP_ADAPTER = :always_trap_adapter
+    UNKNOWN = :unknown
+  end
+end

--- a/spec/unit/error_spec.rb
+++ b/spec/unit/error_spec.rb
@@ -1,0 +1,62 @@
+require "spec_helper"
+
+module Wasmtime
+  RSpec.describe "Error" do
+    let(:error_class) { Class.new(StandardError) }
+
+    context "on instance start" do
+      context "from Instance.new" do
+        it "bubbles host exception" do
+          func = Func.new(store, FuncType.new([], [])) { raise error_class }
+
+          expect { Wasmtime::Instance.new(store, module_import_func_start, [func]) }
+            .to raise_error(error_class)
+        end
+      end
+
+      context "from Linker#instantiate" do
+        it "bubbles host exception" do
+          linker = Linker.new(engine)
+          linker.func_new("", "", FuncType.new([], [])) { raise error_class }
+          store = Store.new(engine)
+
+          expect { linker.instantiate(store, module_import_func_start) }.to raise_error(error_class)
+        end
+      end
+    end
+
+    context "on call" do
+      context "from Func#call" do
+        it "bubbles host exception" do
+          store = Store.new(engine)
+          func = Func.new(store, FuncType.new([], [])) { raise error_class }
+
+          expect { func.call }.to raise_error(error_class)
+        end
+      end
+
+      context "from Instance#invoke" do
+        it "bubbles host exception" do
+          store = Store.new(engine)
+          mod = Module.new(engine, <<~WAT)
+            (module
+              (import "" "" (func))
+              (export "f" (func 0)))
+          WAT
+          func = Func.new(store, FuncType.new([], [])) { raise error_class }
+          instance = Wasmtime::Instance.new(store, mod, [func])
+
+          expect { instance.invoke("f") }.to raise_error(error_class)
+        end
+      end
+    end
+
+    def module_import_func_start
+      Wasmtime::Module.new(engine, <<~WAT)
+        (module
+          (import "" "" (func))
+          (start 0))
+      WAT
+    end
+  end
+end

--- a/spec/unit/func_spec.rb
+++ b/spec/unit/func_spec.rb
@@ -58,27 +58,6 @@ module Wasmtime
       skip("TODO!")
     end
 
-    it "bubbles the exception on with call" do
-      error_class = Class.new(StandardError)
-      func = build_func([], []) { raise error_class }
-      expect { func.call }.to raise_error(error_class)
-      # Run a second time to catch already borrowed issues
-      expect { func.call }.to raise_error(error_class)
-    end
-
-    it "bubbles the exception on start" do
-      error_class = Class.new(StandardError)
-      func = Func.new(store, FuncType.new([], [])) { raise error_class }
-      mod = Wasmtime::Module.new(engine, <<~WAT)
-        (module
-          (import "" "" (func))
-          (start 0))
-      WAT
-
-      expect { Wasmtime::Instance.new(store, mod, [func]) }
-        .to raise_error(error_class)
-    end
-
     it "re-enters into Wasm from Ruby" do
       called = false
       func1 = Func.new(store, FuncType.new([], [])) { called = true }

--- a/spec/unit/linker_spec.rb
+++ b/spec/unit/linker_spec.rb
@@ -146,21 +146,6 @@ module Wasmtime
       expect(instance).to be_instance_of(Instance)
     end
 
-    it "instantiate bubbles exceptions from the start func" do
-      error_class = Class.new(StandardError)
-      mod = Wasmtime::Module.new(engine, <<~WAT)
-        (module
-          (import "" "" (func))
-          (start 0))
-      WAT
-      functype = FuncType.new([], [])
-      linker = new_linker
-      linker.func_new("", "", functype) { raise error_class }
-
-      expect { linker.instantiate(Store.new(engine), mod) }
-        .to raise_error(error_class)
-    end
-
     it "get_default" do
       linker = new_linker
       store = Store.new(engine)

--- a/spec/unit/trap_spec.rb
+++ b/spec/unit/trap_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+module Wasmtime
+  RSpec.describe Trap do
+    let(:trap) do
+      Wasmtime::Instance.new(store, module_trapping_on_start)
+    rescue Trap => trap
+      trap
+    end
+
+    describe "#message" do
+      it "has the full message including backtrace" do
+        expect(trap.message).to eq(<<~MSG)
+          wasm trap: wasm `unreachable` instruction executed
+          wasm backtrace:
+              0:   0x1a - <unknown>!<wasm function 0>
+        MSG
+      end
+    end
+
+    describe "#trap_code" do
+      it "returns a symbol matching a constant" do
+        expect(trap.trap_code).to eq(TrapCode::UNREACHABLE_CODE_REACHED)
+      end
+    end
+
+    describe "#to_s" do
+      it "is the same as message" do
+        expect(trap.to_s).to eq(trap.message)
+      end
+    end
+
+    describe "#inspect" do
+      it "looks pretty" do
+        expect(trap.inspect).to match(/\A#<Wasmtime::Trap:0x\h{16} @trap_code=:unreachable_code_reached>$/)
+      end
+    end
+
+    def module_trapping_on_start
+      Wasmtime::Module.new(engine, <<~WAT)
+        (module
+          (func unreachable)
+          (start 0))
+      WAT
+    end
+  end
+end


### PR DESCRIPTION
Closes #24

This PR is (mainly) split in 2 commits:
1. Refactor code and tests so that Wasm error handling happens in 1 place
2. Add `Trap` exception


The perfect solution for defining enums would've had the following properties:
- Self-documenting
- Protect against typos (e.g. not just symbols)
- Can be used in with `case` (e.g. not just methods)
- Easy to keep in sync between Rust and Ruby

This is the closest I could come that ticked most of these boxes. The
current solution's downside is that if you add a trap code, you need
to go and update the Ruby file too.

---

I decided not to implement `Trap#trace` and the frames stuff because (1) it's a net addition (2) I don't have a use case for it yet and (3) it isn't the most pressing thing.