### PR TITLE
Prepare for prerelease

### DIFF
--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Smoke gem install
         if: matrix.ruby-platform == 'x86_64-linux' # GitHub actions architecture
         run: |
-          gem install pkg/wasmtime-rb-*.gem --verbose
+          gem install pkg/wasmtime-*.gem --verbose
           script="puts Wasmtime::Engine.new.precompile_module('(module)')"
           ruby -rwasmtime -e "$script" | grep wasmtime-aot
           echo "✅ Successfully gem installed"
@@ -78,7 +78,7 @@ jobs:
         shell: bash
         run: |
           bundle exec rake build
-          gem install pkg/wasmtime-rb-*.gem --verbose
+          gem install pkg/wasmtime-*.gem --verbose
           script="puts Wasmtime::Engine.new(Wasmtime::Config.new).precompile_module('(module)')"
           ruby -rwasmtime -e "$script" | grep wasmtime-aot
           echo "✅ Successfully gem installed"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+---
+name: Release
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+    tags:
+      - v*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check CI success
+        if: ${{ github.event.workflow_run.conclusion != 'success' }}
+        run: exit 1
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+
+      - name: Ensure version matches the tag
+        run: |
+          GEM_VERSION=$(grep VERSION lib/wasmtime/version.rb | head -n 1 | cut -d'"' -f2)
+          if [ "v$GEM_VERSION" != "${{ github.ref_name }}" ]; then
+            echo "Gem version does not match tag"
+            echo "  v$GEM_VERSION != ${{ github.ref_name }}"
+            exit 1
+          fi
+
+      - name: Download artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          name: cross-gem
+          workflow: build-gems.yml
+
+      - name: Push Gem
+        working-directory: pkg/
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_KEY }}
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+
+          ls -l
+          for i in *.gem; do
+            if [ -f "$i" ]; then
+              if ! gem push "$i" >push.out; then
+                gemerr=$?
+                sed 's/^/::error:: /' push.out
+                if ! grep -q "Repushing of gem" push.out; then
+                  exit $gemerr
+                fi
+              fi
+            fi
+          done
+
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+## Getting started
+
+Install dependencies:
+
+```
+bundle install
+```
+
+Compile the gem, run the tests & Ruby linter:
+
+```
+bundle exec rake
+```
+
+## Releasing
+
+1. Bump the `VERSION` in `lib/wasmtime/version.rb`
+1. Create a new tag for that release, prefixed with `v` (`git tag v1.0.0`):
+  
+  ```
+  git tag v$(grep VERSION lib/wasmtime/version.rb | head -n 1 | cut -d'"' -f2)
+  git push --tags
+  ```
+1. The release workflow will run and push a new version to RubyGems and create
+   a new draft release on GitHub. Edit the release notes if needed, then
+   mark the release as published when the release workflow succeeds.

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in wasmtime-rb.gemspec
+# Specify your gem's dependencies in wasmtime.gemspec
 gemspec
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    wasmtime-rb (0.1.0)
+    wasmtime (0.1.0)
       rb_sys (~> 0.9.39)
 
 GEM
@@ -90,7 +90,7 @@ DEPENDENCIES
   rspec (~> 3.1)
   ruby-lsp
   standard (~> 1.18)
-  wasmtime-rb!
+  wasmtime!
   yard
   yard-rustdoc (~> 0.2)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    wasmtime (0.1.0)
+    wasmtime (0.3.0)
       rb_sys (~> 0.9.39)
 
 GEM

--- a/lib/wasmtime/version.rb
+++ b/lib/wasmtime/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wasmtime
-  VERSION = "0.1.0"
+  VERSION = "0.3.0"
 end

--- a/rakelib/compile.rake
+++ b/rakelib/compile.rake
@@ -1,6 +1,6 @@
 require "rake/extensiontask"
 
-GEMSPEC = Bundler.load_gemspec("wasmtime-rb.gemspec")
+GEMSPEC = Bundler.load_gemspec("wasmtime.gemspec")
 
 CROSS_PLATFORMS = [ENV["RUBY_TARGET"]].compact
 

--- a/wasmtime.gemspec
+++ b/wasmtime.gemspec
@@ -3,7 +3,7 @@
 require_relative "lib/wasmtime/version"
 
 Gem::Specification.new do |spec|
-  spec.name = "wasmtime-rb"
+  spec.name = "wasmtime"
   spec.version = Wasmtime::VERSION
   spec.authors = ["Ian Ker-Seymer"]
   spec.email = ["hello@ianks.com"]

--- a/wasmtime.gemspec
+++ b/wasmtime.gemspec
@@ -5,8 +5,8 @@ require_relative "lib/wasmtime/version"
 Gem::Specification.new do |spec|
   spec.name = "wasmtime"
   spec.version = Wasmtime::VERSION
-  spec.authors = ["Ian Ker-Seymer"]
-  spec.email = ["hello@ianks.com"]
+  spec.authors = ["The Wasmtime Project Developers"]
+  spec.email = ["hello@bytecodealliance.org"]
 
   spec.summary = "Wasmtime bindings for Ruby"
   spec.description = "A Ruby binding for Wasmtime, a WebAssembly runtime."


### PR DESCRIPTION
Prepare for a pre-release to RubyGems:

- Rename the gem to `wasmtime` (no `-rb`)

- Change gemspec author to BytecodeAlliance
  This is what [Wasmtime](https://github.com/bytecodealliance/wasmtime/blob/54cfa4df3418961b22a6d5c16a2954b107341080/Cargo.toml#L104) and the Python bindings do.

- Add release workflow
  I developped the workflow against a private fork -- [`wasmtime-jb`](https://rubygems.org/gems/wasmtime-jb/versions). I was testing in a simplified environment but should be close enough that it'll work here 🤞.

- Bump version
  ~I picked `2.0.2-alpha1` given the [versioning policy is that bindings should map to a Wasmtime release](https://bytecodealliance.org/articles/wasmtime-1-0-fast-safe-and-production-ready#:~:text=For%20example%2C%20if%20you%20use%20wasmtime%2Dpy%207.0%2C%20you%20can%20be%20sure%20that%20you%E2%80%99re%20using%20Wasmtime%207.0.).~
  After chatting with Saúl, we chose `0.3.0` so that when we release a "stable" version we can start following Wasmtime's normal versioning scheme.

- Add CONTRIBUTING.md
  For now that's mostly to document the release process.
