### PR TITLE
Fix build "smoke test" step from Wasmtime 3

### DIFF
--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           gem install pkg/wasmtime-rb-*.gem --verbose
           script="puts Wasmtime::Engine.new.precompile_module('(module)')"
-          ruby -rwasmtime -e "$script" | grep wasmtime-aot
+          ruby -rwasmtime -e "$script" | grep wasmtime.info
           echo "✅ Successfully gem installed"
 
   source:


### PR DESCRIPTION
Running this locally, I can't find `wasmtime-aot` in the binary.