### PR TITLE
Refactor specs

### DIFF
--- a/spec/convert_spec.rb
+++ b/spec/convert_spec.rb
@@ -1,0 +1,85 @@
+require "spec_helper"
+
+module Wasmtime
+  RSpec.describe "Type conversions" do
+    describe "for numbers" do
+      [
+        [:i32, 4],
+        [:i64, 2**40],
+        [:f32, 5.5],
+        [:f64, 5.5]
+      ].each do |type, value|
+        it "converts #{type} back and forth" do
+          expect(roundtrip_value(type, value)).to eq(value)
+        end
+      end
+
+      it "raises on i32 overflow" do
+        expect { roundtrip_value(:i32, 2**50) }.to raise_error(RangeError)
+      end
+
+      it "raises on i64 overflow" do
+        expect { roundtrip_value(:i64, 2**65) }.to raise_error(RangeError)
+      end
+
+      it "returns FLOAT::INFINITY on f32 overflow" do
+        expect(roundtrip_value(:f32, 5 * 10**40)).to eq(Float::INFINITY)
+      end
+
+      it "returns FLOAT::INFINITY on f64 overflow" do
+        expect(roundtrip_value(:f64, 2 * 10**310)).to eq(Float::INFINITY)
+      end
+    end
+
+    describe "for externref" do
+      let(:basic_object) { BasicObject.new }
+
+      it("converts nil back and forth") { expect(roundtrip_value(:externref, nil)).to be_nil }
+      it("converts string back and forth") { expect(roundtrip_value(:externref, "foo")).to eq("foo") }
+      it "converts BasicObject back and forth" do
+        expect(roundtrip_value(:externref, basic_object)).to equal(basic_object)
+      end
+    end
+
+    it "converts ref.null to nil" do
+      instance = compile(<<~WAT)
+        (module
+          (func (export "main") (result externref)
+            ref.null extern))
+      WAT
+      expect(instance.invoke("main")).to be_nil
+    end
+
+    describe "for funcref" do
+      it "converts back and forth" do
+        store = Store.new(engine)
+        f1 = Func.new(store, FuncType.new([], [])) {}
+        f2 = Func.new(store, FuncType.new([:funcref], [:funcref])) { |_, arg1| arg1 }
+        returned_func = f2.call(f1)
+        expect(returned_func).to be_instance_of(Func)
+      end
+
+      it "converts ref.null to nil" do
+        instance = compile(<<~WAT)
+          (module
+            (func (export "main") (result funcref)
+              ref.null func))
+        WAT
+        expect(instance.invoke("main")).to be_nil
+      end
+    end
+
+    private
+
+    def roundtrip_value(type, value)
+      Func
+        .new(
+          Store.new(engine),
+          FuncType.new([type], [type])
+        ) do |_caller, arg|
+          arg
+        end
+        .call(value)
+    end
+  end
+end

--- a/spec/unit/engine_spec.rb
+++ b/spec/unit/engine_spec.rb
@@ -4,25 +4,25 @@ module Wasmtime
   RSpec.describe Engine do
     let(:engine) { Engine.new(Wasmtime::Config.new) }
 
-    describe(".new") do
+    describe ".new" do
       it("accepts a config") { Engine.new(Wasmtime::Config.new) }
       it("accepts no config") { Engine.new }
       it("accepts nil config") { Engine.new(nil) }
-      it("rejects non-config arg") do
+      it "rejects non-config arg" do
         expect { Engine.new(1) }.to raise_error(TypeError)
       end
-      it("rejects multiple args") do
+      it "rejects multiple args" do
         expect { Engine.new(1, 2) }.to raise_error(ArgumentError)
       end
     end
 
-    describe(".precompile_module") do
-      it("returns a String") do
+    describe ".precompile_module" do
+      it "returns a String" do
         serialized = engine.precompile_module("(module)")
         expect(serialized).to be_instance_of(String)
       end
 
-      it("can be used by Module.deserialize") do
+      it "can be used by Module.deserialize" do
         serialized = engine.precompile_module("(module)")
         mod = Module.deserialize(engine, serialized)
         expect(mod).to be_instance_of(Wasmtime::Module)

--- a/spec/unit/func_spec.rb
+++ b/spec/unit/func_spec.rb
@@ -2,100 +2,66 @@ require "spec_helper"
 
 module Wasmtime
   RSpec.describe Func do
-    it "accepts block" do
-      store = Store.new(engine, {})
-      func = Func.new(store, FuncType.new([], [])) {}
-      func.call
-    end
-
-    it "raises without a block" do
-      expect { build_func([], []) }
-        .to raise_error(ArgumentError)
-    end
-
-    it("converts i32 back and forth") { expect(roundtrip_value(:i32, 4)).to eq(4) }
-    it("converts i64 back and forth") { expect(roundtrip_value(:i64, 2**40)).to eq(2**40) }
-    it("converts f32 back and forth") { expect(roundtrip_value(:f32, 5.5)).to eq(5.5) }
-    it("converts f64 back and forth") { expect(roundtrip_value(:f64, 5.5)).to eq(5.5) }
-    it("converts nil externref back and forth") { expect(roundtrip_value(:externref, nil)).to be_nil }
-    it("converts string externref back and forth") { expect(roundtrip_value(:externref, "foo")).to eq("foo") }
-
-    it "converts BasicObject externref back and forth" do
-      obj = BasicObject
-      expect(roundtrip_value(:externref, obj)).to equal(obj)
-    end
-
-    it "converts ref.null into nil for externref" do
-      instance = compile(<<~WAT)
-        (module
-          (func (export "main") (result externref)
-            ref.null extern))
-      WAT
-      expect(instance.invoke("main")).to be_nil
-    end
-
-    it "converts funcref back and forth" do
-      store = Store.new(engine)
-      f1 = Func.new(store, FuncType.new([], [])) {}
-      f2 = Func.new(store, FuncType.new([:funcref], [:funcref])) { |_, arg1| arg1 }
-      returned_func = f2.call(f1)
-      expect(returned_func).to be_instance_of(Func)
-    end
-
-    it "converts ref.null into nil for funcref" do
-      instance = compile(<<~WAT)
-        (module
-          (func (export "main") (result funcref)
-            ref.null func))
-      WAT
-      expect(instance.invoke("main")).to be_nil
-    end
-
-    it "ignores the proc's return value when func has no results" do
-      func = build_func([], []) { 1 }
-      expect(func.call).to be_nil
-    end
-
-    it "accepts array of 1 element for single result" do
-      func = build_func([], [:i32]) { [1] }
-      expect(func.call).to eq(1)
-    end
-
-    it "rejects mismatching results size" do
-      func = build_func([], [:i32]) { [1, 2] }
-      expect { func.call }.to raise_error(Wasmtime::Error, /wrong number of results \(given 2, expected 1\)/)
-    end
-
-    it "rejects mismatching result type" do
-      func = build_func([], [:i32]) { [nil] }
-      expect { func.call }.to raise_error(Wasmtime::Error)
-    end
-
-    it "tells you which result failed to convert in the error message" do
-      skip("TODO!")
-    end
-
-    it "re-enters into Wasm from Ruby" do
-      called = false
-      func1 = Func.new(store, FuncType.new([], [])) { called = true }
-      func2 = Func.new(store, FuncType.new([], [])) { func1.call }
-      func2.call
-      expect(called).to be true
-    end
-
-    it "sends caller as first argument" do
-      called = false
-      store_data = BasicObject.new
-
-      store = Store.new(engine, store_data)
-      func = Func.new(store, FuncType.new([:i32], [])) do |caller, _|
-        called = true
-        expect(caller).to be_instance_of(Caller)
-        expect(caller.store_data).to equal(store_data)
+    describe ".new" do
+      it "accepts block" do
+        store = Store.new(engine, {})
+        func = Func.new(store, FuncType.new([], [])) {}
+        func.call
       end
 
-      func.call(1)
-      expect(called).to be true
+      it "raises without a block" do
+        expect { build_func([], []) }
+          .to raise_error(ArgumentError)
+      end
+    end
+
+    describe ".call" do
+      it "ignores the proc's return value when func has no results" do
+        func = build_func([], []) { 1 }
+        expect(func.call).to be_nil
+      end
+
+      it "accepts array of 1 element for single result" do
+        func = build_func([], [:i32]) { [1] }
+        expect(func.call).to eq(1)
+      end
+
+      it "rejects mismatching results size" do
+        func = build_func([], [:i32]) { [1, 2] }
+        expect { func.call }.to raise_error(Wasmtime::Error, /wrong number of results \(given 2, expected 1\)/)
+      end
+
+      it "rejects mismatching result type" do
+        func = build_func([], [:i32]) { [nil] }
+        expect { func.call }.to raise_error(Wasmtime::Error)
+      end
+
+      it "tells you which result failed to convert in the error message" do
+        skip("TODO!")
+      end
+
+      it "re-enters into Wasm from Ruby" do
+        called = false
+        func1 = Func.new(store, FuncType.new([], [])) { called = true }
+        func2 = Func.new(store, FuncType.new([], [])) { func1.call }
+        func2.call
+        expect(called).to be true
+      end
+
+      it "sends caller as first argument" do
+        called = false
+        store_data = BasicObject.new
+
+        store = Store.new(engine, store_data)
+        func = Func.new(store, FuncType.new([:i32], [])) do |caller, _|
+          called = true
+          expect(caller).to be_instance_of(Caller)
+          expect(caller.store_data).to equal(store_data)
+        end
+
+        func.call(1)
+        expect(called).to be true
+      end
     end
 
     describe "Caller" do
@@ -140,11 +106,6 @@ module Wasmtime
     end
 
     private
-
-    def roundtrip_value(type, value)
-      build_func([type], [type]) { |_, arg| arg }
-        .call(value)
-    end
 
     def build_func(params, results, &block)
       store = Store.new(engine, {})

--- a/spec/unit/func_type_spec.rb
+++ b/spec/unit/func_type_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 module Wasmtime
   RSpec.describe FuncType do
-    it("accepts supported Wasm types") do
+    it "accepts supported Wasm types" do
       supported_types = [:i32, :i64, :f32, :f64, :v128, :funcref, :externref]
       supported_types.each do |type|
         ty = FuncType.new([type], [])
@@ -15,12 +15,12 @@ module Wasmtime
       end
     end
 
-    it("rejects unknown symbols") do
+    it "rejects unknown symbols" do
       expect { FuncType.new([:nope], []) }
         .to raise_error(Wasmtime::Error, /expected one of \[:i32, :i64, :f32, :f64, :v128, :funcref, :externref\], got :nope/)
     end
 
-    it("rejects non-symbols") do
+    it "rejects non-symbols" do
       expect { FuncType.new(nil, nil) }.to raise_error(Wasmtime::Error)
       expect { FuncType.new([1], [2]) }.to raise_error(Wasmtime::Error)
     end

--- a/spec/unit/memory_spec.rb
+++ b/spec/unit/memory_spec.rb
@@ -2,49 +2,61 @@ require "spec_helper"
 
 module Wasmtime
   RSpec.describe Memory do
-    it "creates a memory" do
-      mem = Memory.new(store, MemoryType.new(1))
-      expect(mem).to be_instance_of(Wasmtime::Memory)
+    describe ".new" do
+      it "creates a memory" do
+        mem = Memory.new(store, MemoryType.new(1))
+        expect(mem).to be_instance_of(Wasmtime::Memory)
+      end
     end
 
-    it "returns its size" do
-      mem = Memory.new(store, MemoryType.new(1))
-      expect(mem.size).to eq(1)
+    describe "#size" do
+      it "returns its size" do
+        mem = Memory.new(store, MemoryType.new(1))
+        expect(mem.size).to eq(1)
+      end
     end
 
-    it "returns its memory type" do
-      mem = Memory.new(store, MemoryType.new(1))
-      expect(mem.ty).to be_instance_of(MemoryType)
-      expect(mem.ty.minimum).to eq(1)
-      expect(mem.ty.maximum).to be_nil
+    describe "#ty" do
+      it "returns its memory type" do
+        mem = Memory.new(store, MemoryType.new(1))
+        expect(mem.ty).to be_instance_of(MemoryType)
+        expect(mem.ty.minimum).to eq(1)
+        expect(mem.ty.maximum).to be_nil
+      end
     end
 
-    it "returns the previous size when growing" do
-      mem = Memory.new(store, MemoryType.new(2))
-      expect(mem.grow(1)).to eq(2)
+    describe "#grow" do
+      it "returns the previous size" do
+        mem = Memory.new(store, MemoryType.new(2))
+        expect(mem.grow(1)).to eq(2)
+      end
+
+      it "raises when growing past the maximum" do
+        mem = Memory.new(store, MemoryType.new(1, 1))
+        expect { mem.grow(1) }.to raise_error(Wasmtime::Error, "failed to grow memory by `1`")
+      end
     end
 
-    it "rejects growing past its maximum" do
-      mem = Memory.new(store, MemoryType.new(1, 1))
-      expect { mem.grow(1) }.to raise_error(Wasmtime::Error, "failed to grow memory by `1`")
-    end
+    describe "#read, #write" do
+      it "reads and writes a Binary string" do
+        mem = Memory.new(store, MemoryType.new(1))
+        expect(mem.write(0, "foo")).to be_nil
+        str = mem.read(0, 3)
+        expect(str).to eq("foo")
+        expect(str.encoding).to eq(Encoding::ASCII_8BIT)
+      end
 
-    it "reads and writes a string" do
-      mem = Memory.new(store, MemoryType.new(1))
-      expect(mem.write(0, "foo")).to be_nil
-      expect(mem.read(0, 3)).to eq("foo")
-    end
+      it "raises when reading past the end of the buffer" do
+        mem = Memory.new(store, MemoryType.new(1))
+        expect { mem.read(64 * 2**10, 1) }
+          .to raise_error(Wasmtime::Error, "out of bounds memory access")
+      end
 
-    it "raises when writing past the end of the buffer" do
-      mem = Memory.new(store, MemoryType.new(1))
-      expect { mem.write(64 * 2**10, "f") }
-        .to raise_error(Wasmtime::Error, "out of bounds memory access")
-    end
-
-    it "raises when reading past the end of the buffer" do
-      mem = Memory.new(store, MemoryType.new(1))
-      expect { mem.read(64 * 2**10, 1) }
-        .to raise_error(Wasmtime::Error, "out of bounds memory access")
+      it "raises when writing past the end of the buffer" do
+        mem = Memory.new(store, MemoryType.new(1))
+        expect { mem.write(64 * 2**10, "f") }
+          .to raise_error(Wasmtime::Error, "out of bounds memory access")
+      end
     end
   end
 end

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -7,22 +7,29 @@ module Wasmtime
   RSpec.describe Module do
     let(:engine) { Engine.new(Wasmtime::Config.new) }
 
-    it("can be serialized and deserialized") do
+    it "can be serialized and deserialized" do
       mod = Module.new(engine, wat)
       serialized = mod.serialize
       deserialized = Module.deserialize(engine, serialized)
       expect(deserialized.serialize).to eq(serialized)
     end
 
-    describe(".from_file") do
-      it("loads the module") do
+    describe ".from_file" do
+      it "loads the module" do
         mod = Module.from_file(engine, "spec/fixtures/empty.wat")
         expect(mod).to be_instance_of(Module)
       end
     end
 
-    describe(".deserialize_file") do
+    describe ".deserialize_file" do
       include_context(:tmpdir)
+      let(:tmpdir) { Dir.mktmpdir }
+
+      after(:each) do
+        FileUtils.rm_rf(tmpdir)
+      rescue Errno::EACCES => e
+        warn "WARN: Failed to remove #{tmpdir} (#{e})"
+      end
 
       it("can deserialize a module from a file") do
         tmpfile = create_tmpfile(Module.new(engine, "(module)").serialize)
@@ -31,7 +38,7 @@ module Wasmtime
         expect(mod.serialize).to eq(Module.new(engine, "(module)").serialize)
       end
 
-      it("deserialize from a module multiple times") do
+      it "deserialize from a module multiple times" do
         tmpfile = create_tmpfile(Module.new(engine, wat).serialize)
 
         mod_one = Module.deserialize_file(engine, tmpfile)
@@ -50,8 +57,8 @@ module Wasmtime
       end
     end
 
-    describe(".deserialize") do
-      it("raises on invalid module") do
+    describe ".deserialize" do
+      it "raises on invalid module" do
         expect { Module.deserialize(engine, "foo") }
           .to raise_error(Wasmtime::Error)
       end

--- a/spec/unit/store_spec.rb
+++ b/spec/unit/store_spec.rb
@@ -2,15 +2,17 @@ require "spec_helper"
 
 module Wasmtime
   RSpec.describe Store do
-    it "default to nil data" do
-      store = Store.new(engine)
-      expect(store.data).to be_nil
-    end
+    describe ".new" do
+      it "default to nil data" do
+        store = Store.new(engine)
+        expect(store.data).to be_nil
+      end
 
-    it "accepts user-provided data" do
-      data = BasicObject.new
-      store = Store.new(engine, data)
-      expect(store.data).to equal(data)
+      it "accepts user-provided data" do
+        data = BasicObject.new
+        store = Store.new(engine, data)
+        expect(store.data).to equal(data)
+      end
     end
   end
 end


### PR DESCRIPTION
- Remove redundant parens for rspec DSL (`it`, `context`, `describe`)
- Extract conversion specs to its own file, and remove duplication between `Func#call` and `Instance#invoke` testing the same thing.
- Use `describe` blocks for most methods, where it made sense.