### PR TITLE
Add custom task to build the source gem

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@main
         with:
           ruby-version: "3.1"
+          bundler-cache: true
+          cargo-cache: true
+          cache-version: v1
 
       - name: Ensure version matches the tag
         run: |
@@ -81,9 +83,7 @@ jobs:
           name: cross-gem
 
       - name: Package source gem
-        run: |
-          GEM_VERSION=$(grep VERSION lib/wasmtime/version.rb | head -n 1 | cut -d'"' -f2)
-          gem build -o pkg/wasmtime-$GEM_VERSION.gem
+        run: bundle exec rake pkg:ruby
 
       - name: Push Gem
         working-directory: pkg/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,9 @@ require: standard
 
 inherit_gem:
   standard: config/base.yml
+
+AllCops:
+  Exclude:
+    - 'vendor/**/*'
+    - 'pkg/**/*'
+    - 'tmp/**/*'

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,3 +1,7 @@
 # For available configuration options, see:
 #   https://github.com/testdouble/standard
 ruby_version: 2.6
+ignore:
+  - 'vendor/**/*'
+  - 'pkg/**/*'
+  - 'tmp/**/*'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,18 +1018,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.44"
+version = "0.9.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f48777b8161ff5c077ad74ce486ebe963ca8a92257512bab473b405a80d69f"
+checksum = "629f4336003407ebdbf74e15e5d538ad4834a6ed949908b94a2cf5f6cb3f01ac"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.44"
+version = "0.9.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a46785122aff7077527b78c2518d739c45dc0fbc410a2b8361076ff4bbf993f9"
+checksum = "934ad26b6ecafb0f0e96d4c10d318387dad109422d9db5050acf9c9f5ac23e6e"
 dependencies = [
  "bindgen",
  "regex",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     wasmtime (0.3.0)
-      rb_sys (~> 0.9.44)
+      rb_sys (~> 0.9.45)
 
 GEM
   remote: https://rubygems.org/
@@ -24,7 +24,7 @@ GEM
     rake (13.0.6)
     rake-compiler (1.2.0)
       rake
-    rb_sys (0.9.44)
+    rb_sys (0.9.45)
     regexp_parser (2.6.1)
     rexml (3.2.5)
     rspec (3.12.0)

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
-
-RSpec::Core::RakeTask.new(:spec)
-
 require "standard/rake"
 
 GEMSPEC = Gem::Specification.load("wasmtime.gemspec")

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,8 @@ RSpec::Core::RakeTask.new(:spec)
 
 require "standard/rake"
 
-task build: :compile
+GEMSPEC = Gem::Specification.load("wasmtime.gemspec")
+
+task build: "pkg:ruby"
 
 task default: %i[compile spec standard]

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 lazy_static = "1.4.0"
 magnus = { git = "https://github.com/matsadler/magnus", features = ["rb-sys-interop"] }
-rb-sys = "~0.9.44"
+rb-sys = "~0.9.45"
 wasmtime = "3.0.0"
 wasmtime-wasi = "3.0.0"
 wasi-common = "3.0.0"

--- a/rakelib/compile.rake
+++ b/rakelib/compile.rake
@@ -1,9 +1,6 @@
 require "rake/extensiontask"
 
-GEMSPEC = Bundler.load_gemspec("wasmtime.gemspec")
-
 CROSS_PLATFORMS = [ENV["RUBY_TARGET"]].compact
-
 SOURCE_PATTERN = "**/src/**/*.{rs,toml,lock}"
 
 Rake::ExtensionTask.new("ext", GEMSPEC) do |ext|

--- a/rakelib/doc.rake
+++ b/rakelib/doc.rake
@@ -1,5 +1,9 @@
 require "yard/rake/yardoc_task"
 
+CLOBBER.include("doc")
+CLEAN.include(".yardoc")
+CLEAN.include("tmp/doc")
+
 YARD::Rake::YardocTask.new do |t|
   t.options += ["--fail-on-warn"]
 
@@ -50,19 +54,16 @@ namespace :doc do
 
   desc "Generate Rust documentation as JSON"
   task :rustdoc do
-    run(<<~CMD)
+    sh <<~CMD
       cargo +nightly rustdoc \
-        --target-dir tmp \
+        --target-dir tmp/doc/target \
         -p ext \
         -- -Zunstable-options --output-format json \
         --document-private-items
     CMD
-  end
 
-  def run(cmd)
-    system(cmd)
-    fail if $? != 0
+    cp "tmp/doc/target/doc/ext.json", "tmp/doc/ext.json"
   end
 end
 
-task doc: "doc:default"
+task doc: ["compile", "doc:default"]

--- a/rakelib/helpers.rake
+++ b/rakelib/helpers.rake
@@ -1,0 +1,10 @@
+def dirglob(pattern)
+  result = Dir.glob(pattern, File::FNM_DOTMATCH)
+  raise "No files found for pattern: #{pattern}" if result.empty?
+  result
+end
+
+def filesize(*files)
+  bytes = files.sum { |f| File.size(f) }
+  (bytes / 1024.0 / 1024.0).round(2)
+end

--- a/rakelib/pkg.rake
+++ b/rakelib/pkg.rake
@@ -1,0 +1,67 @@
+CLOBBER.include("pkg/**/*.gem")
+CLEAN.include("tmp/pkg")
+CLEAN.include("tmp/pkg")
+
+namespace :pkg do
+  directory "pkg"
+
+  desc "Build the source gem (#{GEMSPEC.name}-#{GEMSPEC.version}.gem)"
+  task ruby: "pkg" do
+    slug = "#{GEMSPEC.name}-#{GEMSPEC.version}"
+    output_gempath = File.expand_path("../pkg/#{slug}.gem", __dir__)
+    gemspec_path = "wasmtime.gemspec"
+    base_dir = File.join("tmp/pkg", slug)
+    staging_dir = File.join(base_dir, "stage")
+    unpacked_dir = File.join(base_dir, "unpacked")
+    vendor_dir = "ext/vendor"
+    staging_gem_path = File.join(staging_dir, "#{slug}.gem")
+
+    puts "Building source gem..."
+
+    rm(output_gempath) if File.exist?(output_gempath)
+    rm_rf(staging_dir)
+    rm_rf(unpacked_dir)
+    mkdir_p(staging_dir)
+    cp(gemspec_path, staging_dir)
+
+    GEMSPEC.files.each do |file|
+      dest = File.join(staging_dir, file)
+      mkdir_p(File.dirname(dest))
+      cp(file, dest) if File.file?(file)
+    end
+
+    Dir.chdir(staging_dir) do
+      cargo_config_path = ".cargo/config"
+      final_gemspec = Gem::Specification.load(File.basename(gemspec_path))
+
+      puts "Vendoring cargo dependencies to #{cargo_config_path}..."
+      mkdir_p ".cargo"
+      sh "cargo vendor --versioned-dirs --locked #{vendor_dir} >> #{cargo_config_path} 2>/dev/null"
+
+      final_gemspec.files += dirglob("**/.cargo/**/*")
+      final_gemspec.files += dirglob("./#{vendor_dir}/**/*")
+      final_gemspec.files.reject! { |f| File.directory?(f) }
+
+      puts "Building gem to #{unpacked_dir}.gem..."
+      Gem::Package.build(final_gemspec, false, true, "#{slug}.gem")
+    end
+
+    puts "Unpacking gem to #{unpacked_dir}..."
+    sh "gem unpack #{staging_gem_path} --target #{File.dirname(unpacked_dir)} --quiet"
+    mv File.join(base_dir, slug), unpacked_dir
+
+    puts "Verifying cargo dependencies are vendored..."
+    sh "cargo verify-project --manifest-path #{File.join(unpacked_dir, "Cargo.toml")}"
+
+    cp staging_gem_path, output_gempath
+
+    puts <<~STATS
+      \n\e[1m==== Source gem stats (#{File.basename(output_gempath)}) ====\e[0m
+      - Path: #{output_gempath.delete_prefix(Dir.pwd + "/")}
+      - Number of files: #{dirglob("#{unpacked_dir}/**/*").count}
+      - Number of vendored deps: #{dirglob("#{unpacked_dir}/#{vendor_dir}/*").count}
+      - Size (packed): #{filesize(output_gempath)} MB
+      - Size (unpacked): #{filesize(*dirglob("#{unpacked_dir}/**/*"))} MB
+    STATS
+  end
+end

--- a/rakelib/pkg.rake
+++ b/rakelib/pkg.rake
@@ -13,7 +13,7 @@ namespace :pkg do
     base_dir = File.join("tmp/pkg", slug)
     staging_dir = File.join(base_dir, "stage")
     unpacked_dir = File.join(base_dir, "unpacked")
-    vendor_dir = "ext/vendor"
+    vendor_dir = "ext/cargo-vendor" # this file gets cleaned up during gem install
     staging_gem_path = File.join(staging_dir, "#{slug}.gem")
 
     puts "Building source gem..."

--- a/rakelib/spec.rake
+++ b/rakelib/spec.rake
@@ -1,0 +1,9 @@
+CLEAN.include(".rspec_status")
+
+begin
+  require "rspec/core/rake_task"
+
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+  # No RSpec installed
+end

--- a/wasmtime.gemspec
+++ b/wasmtime.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "https://github.com/bytecodealliance/wasmtime-rb/blob/main/CHANGELOG.md"
 
   spec.files = Dir["{lib,ext}/**/*", "LICENSE", "README.md", "Cargo.*"]
+  spec.files.reject! { |f| File.directory?(f) }
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/wasmtime.gemspec
+++ b/wasmtime.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |spec|
 
   spec.extensions = ["ext/extconf.rb"] # Future: ["ext/Cargo.toml"] with rubygems >= 3.3.24
 
+  spec.rdoc_options += ["--exclude", "vendor"]
+
   # Can be removed for binary gems and rubygems >= 3.3.24
   spec.add_dependency "rb_sys", "~> 0.9.44"
 end

--- a/wasmtime.gemspec
+++ b/wasmtime.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.rdoc_options += ["--exclude", "vendor"]
 
   # Can be removed for binary gems and rubygems >= 3.3.24
-  spec.add_dependency "rb_sys", "~> 0.9.44"
+  spec.add_dependency "rb_sys", "~> 0.9.45"
 end


### PR DESCRIPTION
This PR adds a new `pkg:ruby` Rake task to bundle a source-code-only version of the gem. This gem is intended for users who cannot use the precompiled gems (i.e. Ruby head, or when `force_ruby_platform` is used with bundler).

Before packaging the gem, this PR vendors the crates necessary for compilation so `gem install` can be done offline, and avoids hitting the cargo registry or github.