### PR TITLE
Add `Wasmtime.wat2wasm`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,7 @@ dependencies = [
  "wasi-common",
  "wasmtime",
  "wasmtime-wasi",
+ "wat",
 ]
 
 [[package]]
@@ -1388,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9424cdab516a16d4ea03c8f4a01b14e7b2d04a129dcc2bcdde5bcc5f68f06c41"
+checksum = "05632e0a66a6ed8cca593c24223aabd6262f256c3693ad9822c315285f010614"
 dependencies = [
  "leb128",
 ]
@@ -1627,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "49.0.0"
+version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ef81fcd60d244cafffeafac3d17615fdb2fddda6aca18f34a8ae233353587c"
+checksum = "a2cbb59d4ac799842791fe7e806fa5dbbf6b5554d538e51cc8e176db6ff0ae34"
 dependencies = [
  "leb128",
  "memchr",
@@ -1639,11 +1640,11 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c347c4460ffb311e95aafccd8c29e4888f241b9e4b3bb0e0ccbd998de2c8c0d"
+checksum = "584aaf7a1ecf4d383bbe1a25eeab0cbb8ff96acc6796707ff65cde48f4632f15"
 dependencies = [
- "wast 49.0.0",
+ "wast 50.0.0",
 ]
 
 [[package]]

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem "get_process_mem"
   gem "ruby-lsp", require: false
   gem "yard", require: false
-  gem "yard-rustdoc", "~> 0.3", require: false
+  gem "yard-rustdoc", "~> 0.3.2", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,23 +55,23 @@ GEM
     rubocop-performance (1.15.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    ruby-lsp (0.3.6)
+    ruby-lsp (0.3.5)
       language_server-protocol (~> 3.17.0)
       sorbet-runtime
-      syntax_tree (>= 4.0.2, < 5.0.0)
+      syntax_tree (>= 4.0.2)
     ruby-progressbar (1.11.0)
     sorbet-runtime (0.5.10554)
     standard (1.18.1)
       rubocop (= 1.39.0)
       rubocop-performance (= 1.15.1)
-    syntax_tree (4.3.0)
-      prettier_print (>= 1.0.2)
+    syntax_tree (5.0.1)
+      prettier_print (>= 1.1.0)
     unicode-display_width (2.3.0)
     webrick (1.7.0)
     yard (0.9.28)
       webrick (~> 1.7.0)
-    yard-rustdoc (0.3.0)
-      syntax_tree (~> 4.0)
+    yard-rustdoc (0.3.2)
+      syntax_tree (~> 5.0)
       yard (~> 0.9)
 
 PLATFORMS
@@ -92,7 +92,7 @@ DEPENDENCIES
   standard (~> 1.18)
   wasmtime!
   yard
-  yard-rustdoc (~> 0.3)
+  yard-rustdoc (~> 0.3.2)
 
 BUNDLED WITH
    2.3.24

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -20,3 +20,4 @@ wasi-cap-std-sync = "3.0.0"
 cap-std = "0.26.0" # Pinned to wasmtime's version
 
 anyhow = "*" # Use whatever Wasmtime uses
+wat = "1.0.52"

--- a/ext/src/ruby_api/memory.rs
+++ b/ext/src/ruby_api/memory.rs
@@ -68,7 +68,7 @@ impl<'a> Memory<'a> {
     /// @def read(offset, size)
     /// @param offset [Integer]
     /// @param size [Integer]
-    /// @return [String] Binary string of the memory.
+    /// @return [String] Binary +String+ of the memory.
     pub fn read(&self, offset: usize, size: usize) -> Result<RString, Error> {
         self.inner
             .data(self.store.context()?)

--- a/ext/src/ruby_api/mod.rs
+++ b/ext/src/ruby_api/mod.rs
@@ -2,7 +2,7 @@
 #![allow(rustdoc::invalid_html_tags)]
 #![allow(rustdoc::bare_urls)]
 #![allow(rustdoc::invalid_rust_codeblocks)]
-use magnus::{define_module, memoize, Error, RModule};
+use magnus::{define_module, function, memoize, Error, RModule, RString};
 
 mod config;
 mod convert;
@@ -28,8 +28,27 @@ pub fn root() -> RModule {
     *memoize!(RModule: define_module("Wasmtime").unwrap())
 }
 
+// This Struct is a placeholder for documentation, so that we can hang methods
+// to it and have yard-rustdoc discover them.
+/// @yard
+/// @module
+pub struct Wasmtime;
+impl Wasmtime {
+    /// @yard
+    /// Converts a WAT +String+ into Wasm.
+    /// @param wat [String]
+    /// @def wat2wasm(wat)
+    /// @return [String] The Wasm represented as a binary +String+.
+    pub fn wat2wasm(wat: RString) -> Result<RString, Error> {
+        wat::parse_str(unsafe { wat.as_str()? })
+            .map(|bytes| RString::from_slice(bytes.as_slice()))
+            .map_err(|e| crate::error!("{}", e))
+    }
+}
+
 pub fn init() -> Result<(), Error> {
-    let _ = root();
+    let wasmtime = root();
+    wasmtime.define_module_function("wat2wasm", function!(Wasmtime::wat2wasm, 1))?;
 
     errors::init()?;
     trap::init()?;

--- a/rakelib/doc.rake
+++ b/rakelib/doc.rake
@@ -15,10 +15,10 @@ YARD::Rake::YardocTask.new do |t|
       case yard_object.type
       when :module
         mod = Object.const_get(yard_object.path)
-        errors << "Not a module: #{mod.path}" unless mod.is_a?(::Module)
+        errors << "Not a module: #{mod}" unless mod.is_a?(::Module)
       when :class
         klass = Object.const_get(yard_object.path)
-        errors << "Not a class: #{klass.path}" unless klass.is_a?(::Class)
+        errors << "Not a class: #{klass}" unless klass.is_a?(::Class)
       when :method
         namespace = Object.const_get(yard_object.namespace.path)
         case yard_object.scope

--- a/spec/unit/wasmtime_spec.rb
+++ b/spec/unit/wasmtime_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+module Wasmtime
+  RSpec.describe Wasmtime do
+    describe ".wat2wasm" do
+      it "returns a binary string" do
+        wasm = Wasmtime.wat2wasm("(module)")
+        expect(wasm.encoding).to eq(Encoding::ASCII_8BIT)
+      end
+
+      it "returns a valid module" do
+        wasm = Wasmtime.wat2wasm("(module)")
+        expect(wasm).to start_with("\x00asm")
+      end
+
+      it "raises on invalid WAT" do
+        expect { Wasmtime.wat2wasm("not wat") }.to raise_error(Wasmtime::Error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a minor addition but would be helpful to have as I'm integrating wasmtime-rb in a real-world project. For my use case I need binary Wasm (not WAT) and would like to test using simple, sample programs. Bundling these as WAT in my test files would be easier than having the binary Wasms.