### PR TITLE
Move native ext SO to `wasmtime` dir

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -3,4 +3,4 @@
 require "mkmf"
 require "rb_sys/mkmf"
 
-create_rust_makefile("ext")
+create_rust_makefile("wasmtime/ext")


### PR DESCRIPTION
Fixes #51

By using `ext` in the makefile, installing from git meant the native extension was placed to `lib/ext.$ext` instead of `lib/wasmtime/ext.$ext`. Using `wasmtime/ext` places the extension in `lib/wasmtime/ext.$ext`. After installing the gem with Bundler pointing to this branch, this is what I get:

```
$ tree ~/.gem/ruby/3.1.2/bundler/gems/wasmtime-rb-3e7bed8333e3/lib
~/.gem/ruby/3.1.2/bundler/gems/wasmtime-rb-3e7bed8333e3/lib
├── wasmtime
│   ├── ext.bundle
│   └── version.rb
└── wasmtime.rb
```

Which is what we expect, and indeed works as expected:

```
$ bundle exec ruby -e 'require "wasmtime"; puts Wasmtime::Engine'
Wasmtime::Engine
```

Outside of fixing the issue, the [build gem action](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/3599109491) completed, and the resulting gem looks fine to me:

```
$ tree wasmtime-0.3.0-arm64-darwin/lib/
wasmtime-0.3.0-arm64-darwin/lib/
├── wasmtime
│   ├── 2.7
│   │   └── ext.bundle
│   ├── 3.0
│   │   └── ext.bundle
│   ├── 3.1
│   │   └── ext.bundle
│   └── version.rb
└── wasmtime.rb
```