### PR TITLE
Allow stdin & stdout to write to String

### DIFF
--- a/ext/src/ruby_api/store.rs
+++ b/ext/src/ruby_api/store.rs
@@ -94,7 +94,8 @@ impl Store {
     ///
     /// @example
     ///   store = Wasmtime::Store.new(Wasmtime::Engine.new, {})
-    pub fn new(args: &[Value]) -> Result<Self, Error> {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(args: &[Value]) -> Result<Value, Error> {
         let args = scan_args::scan_args::<(&Engine,), (Option<Value>,), (), (), _, ()>(args)?;
         let kw = scan_args::get_kwargs::<_, (), (Option<&WasiCtxBuilder>,), ()>(
             args.keywords,
@@ -133,7 +134,9 @@ impl Store {
             store.retain(*s);
         }
 
-        Ok(store)
+        // Turn the store into a Value while wasi_stdout and wasi_stderr are
+        // still on the stack, otherwise they get GC'd.
+        Ok(store.into())
     }
 
     /// @yard

--- a/spec/unit/wasi_spec.rb
+++ b/spec/unit/wasi_spec.rb
@@ -50,6 +50,19 @@ module Wasmtime
         expect(stdout.dig("wasi", "stdin")).to eq("stdin content")
       end
 
+      it "writes std streams to strings" do
+        wasi_config = WasiCtxBuilder.new
+          .set_stdout_string
+          .set_stderr_string
+
+        store = run_wasi_module(wasi_config)
+        stdout = JSON.parse(store.wasi_stdout_string)
+        stderr = JSON.parse(store.wasi_stderr_string)
+
+        expect(stdout.fetch("name")).to eq("stdout")
+        expect(stderr.fetch("name")).to eq("stderr")
+      end
+
       it "reads stdin from string" do
         env = wasi_module_env { |config| config.set_stdin_string("¡UTF-8 from Ruby!") }
         expect(env.fetch("stdin")).to eq("¡UTF-8 from Ruby!")
@@ -84,6 +97,8 @@ module Wasmtime
       linker = Linker.new(engine, wasi: true)
       store = Store.new(engine, wasi_ctx: wasi_ctx_builder)
       linker.instantiate(store, wasi_module).invoke("_start")
+
+      store
     end
 
     def wasi_module_env


### PR DESCRIPTION
Allow WASI's stdin and stdout to write to a Ruby String, which can then be read back from the store.

Opening this as a draft PR because I'm not overly satisfied with the current state:
- the API is clunky, getting stdin/out directly from the Store feels odd. Other possible approaches:
  - introducing `Store#wasi_ctx` that returns a WASI context with the 2 methods on it (but I don't know what else it would ever have, and exposing more methods probably means more data copy, thus slight perf cost)
  - taking a (non frozen) string in `#set_stdin_string`, and modifying that string in place.
- There's a missing abstraction for the `(wasi ctx, stdout string, stderr string)` tuple.