### PR TITLE
Add `mswin` to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         ruby: ${{ fromJSON(needs.ci-data.outputs.result).stable-ruby-versions }}
+        include:
+          - os: windows-latest
+            ruby: mswin
     steps:
       - uses: actions/checkout@v3
 
@@ -85,5 +88,3 @@ jobs:
       - name: Publish doc
         if: contains(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
         uses: ./.github/actions/publish-doc
-        # with:
-        #   github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ruby 3.2 plans to support `mswin` officially, and I've added support to `rb-sys`, `magnus`, and `oxidize-rb/actions`. This PR enables testing against `mswin` in CI.

Note: there's no clear path on precompiled gems for `mswin`, but we should at least test against it.