### PR TITLE
Use `magnus` release from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,8 +819,9 @@ dependencies = [
 
 [[package]]
 name = "magnus"
-version = "0.4.0"
-source = "git+https://github.com/matsadler/magnus#d6f41528f35ed83aaedae1131dce0553d06953e8"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5f7b798b39aaa0781f3c34f5c8d510d0990b43f8ff6fbd20709d1edfbac5201"
 dependencies = [
  "magnus-macros",
  "rb-sys",
@@ -830,7 +831,8 @@ dependencies = [
 [[package]]
 name = "magnus-macros"
 version = "0.2.0"
-source = "git+https://github.com/matsadler/magnus#d6f41528f35ed83aaedae1131dce0553d06953e8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acc8ba6908cb0f67a4e75cb48fc81a1f0e6a6dd1501936e0c9e2c7c8f9f18e05"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -11,12 +11,11 @@ crate-type = ["cdylib"]
 
 [dependencies]
 lazy_static = "1.4.0"
-magnus = { git = "https://github.com/matsadler/magnus", features = ["rb-sys-interop"] }
+magnus = { version = "0.4.2", features = ["rb-sys-interop"] }
 rb-sys = "~0.9.45"
 wasmtime = "3.0.0"
 wasmtime-wasi = "3.0.0"
 wasi-common = "3.0.0"
 wasi-cap-std-sync = "3.0.0"
 cap-std = "0.26.0" # Pinned to wasmtime's version
-
 anyhow = "*" # Use whatever Wasmtime uses


### PR DESCRIPTION
`magnus` has cut an official release for all of the features added over the last few months, which mean we can use the [official crates.io version](https://crates.io/crates/magnus).