### PR TITLE
Add rake task to run examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
         env:
           GC_STRESS: "true"
 
+      - name: Run examples
+        run: bundle exec rake examples
+
       - name: Lint ruby
         run: bundle exec rake standard
 

--- a/examples/hello.rb
+++ b/examples/hello.rb
@@ -2,7 +2,8 @@ require "wasmtime"
 
 engine = Wasmtime::Engine.new
 mod = Wasmtime::Module.from_file(engine, "examples/hello.wat")
-store = Wasmtime::Store.new(engine, {count: 0})
+data = {count: 0}
+store = Wasmtime::Store.new(engine, data)
 func = Wasmtime::Func.new(store, Wasmtime::FuncType.new([], [])) do |caller|
   puts "Hello from Func!"
   caller.store_data[:count] += 1

--- a/examples/hello.rb
+++ b/examples/hello.rb
@@ -1,15 +1,27 @@
 require "wasmtime"
 
+class MyData
+  attr_reader :count
+
+  def initialize
+    @count = 0
+  end
+
+  def increment!
+    @count += 1
+  end
+end
+
+data = MyData.new
 engine = Wasmtime::Engine.new
 mod = Wasmtime::Module.from_file(engine, "examples/hello.wat")
-data = {count: 0}
 store = Wasmtime::Store.new(engine, data)
 func = Wasmtime::Func.new(store, Wasmtime::FuncType.new([], [])) do |caller|
   puts "Hello from Func!"
-  caller.store_data[:count] += 1
+  caller.store_data.increment!
 end
 
 instance = Wasmtime::Instance.new(store, mod, [func])
 instance.invoke("run")
 
-puts "Store's count: #{store.data[:count]}"
+puts "Store's count: #{store.data.count}"

--- a/rakelib/examples.rake
+++ b/rakelib/examples.rake
@@ -1,0 +1,18 @@
+namespace :examples do
+  task all: :compile
+
+  Dir.glob("examples/*.rb").each do |path|
+    task_name = File.basename(path, ".rb")
+
+    desc "Run #{path}"
+    task task_name do
+      sh "ruby -Ilib #{path}"
+      puts
+    end
+
+    task all: task_name
+  end
+end
+
+desc "Run all the examples"
+task examples: "examples:all"


### PR DESCRIPTION
This PR adds some tasks to make make running examples easier:

```
rake examples        # Run all the examples
rake examples:gcd    # Run examples/gcd.rb
rake examples:hello  # Run examples/hello.rb
rake examples:wasi   # Run examples/wasi.rb
```

Currently, the `wasi.rb` example is failing. Would like to run this check in CI, so should we hold off merging until that is fixed?