### PR TITLE
Add env configurations for `dev` and `release`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RSPEC_FORMATTER: doc
+
 jobs:
   ci-data:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,10 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
           cargo-cache: true
-          cache-version: v1
+          cache-version: v2
 
       - name: Compile rust ext
-        run: bundle exec rake compile
+        run: bundle exec rake compile:release
 
       - name: Run ruby tests
         run: bundle exec rake spec

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,7 @@
 [workspace]
 members = ["ext"]
+
+[profile.release]
+codegen-units = 1
+debug = 1
+strip = true

--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,4 @@ GEMSPEC = Gem::Specification.load("wasmtime.gemspec")
 
 task build: "pkg:ruby"
 
-task default: %i[compile spec standard]
+task default: %w[env:dev compile spec standard]

--- a/rakelib/compile.rake
+++ b/rakelib/compile.rake
@@ -17,3 +17,11 @@ Rake::ExtensionTask.new("ext", GEMSPEC) do |ext|
     gem_spec.files -= Dir[SOURCE_PATTERN, "**/Cargo.*", "**/extconf.rb"]
   end
 end
+
+namespace :compile do
+  desc 'Compile the extension in "release" mode'
+  task release: ["env:release", "compile"]
+
+  desc 'Compile the extension in "dev" mode'
+  task dev: ["env:dev", "compile"]
+end

--- a/rakelib/env.rake
+++ b/rakelib/env.rake
@@ -1,0 +1,13 @@
+namespace :env do
+  desc 'Sets up environment variables "dev" builds'
+  task :dev do
+    ENV["RUST_BACKTRACE"] = "1"
+    ENV["WASMTIME_BACKTRACE_DETAILS"] = "1"
+    ENV["RB_SYS_CARGO_PROFILE"] ||= "dev"
+  end
+
+  desc 'Sets up environment variables "release" builds'
+  task :release do
+    ENV["RB_SYS_CARGO_PROFILE"] = "release"
+  end
+end

--- a/rakelib/mem.rake
+++ b/rakelib/mem.rake
@@ -65,7 +65,7 @@ namespace :mem do
 
       RubyMemcheck.config(binary_name: "ext")
 
-      RubyMemcheck::RSpec::RakeTask.new(check: "compile:release")
+      RubyMemcheck::RSpec::RakeTask.new(check: "compile:dev")
     rescue LoadError
       task :check do
         abort 'Please add `gem "ruby_memcheck"` to your Gemfile to use the "mem:check" task'

--- a/rakelib/mem.rake
+++ b/rakelib/mem.rake
@@ -65,7 +65,7 @@ namespace :mem do
 
       RubyMemcheck.config(binary_name: "ext")
 
-      RubyMemcheck::RSpec::RakeTask.new(check: :compile)
+      RubyMemcheck::RSpec::RakeTask.new(check: "compile:release")
     rescue LoadError
       task :check do
         abort 'Please add `gem "ruby_memcheck"` to your Gemfile to use the "mem:check" task'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,7 +45,9 @@ RSpec.configure do |config|
 
   # So memcheck steps can still pass if RSpec fails
   config.failure_exit_code = ENV.fetch("RSPEC_FAILURE_EXIT_CODE", 1).to_i
-  config.default_formatter = ENV.fetch("RSPEC_FORMATTER", "doc")
+  config.default_formatter = ENV.fetch("RSPEC_FORMATTER") do
+    config.files_to_run.one? ? "doc" : "progress"
+  end
 
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status" unless ENV["CI"]


### PR DESCRIPTION
This PR makes it do we explicitly configure build profiles when compiling the extension.

### New tasks

```
rake env:dev          # Sets up environment variables "dev" builds
rake env:release      # Sets up environment variables "release" builds
rake compile:dev      # Compile the extension in "dev" mode
rake compile:release  # Compile the extension in "release" mode
```


### Default behavior

- **Local development**: compile in `dev` mode (so overflow checks are configured and debugging is easier)
- **CI**: compile in `release` mode to make sure things works with that profile