### PR TITLE
Add table support

### DIFF
--- a/ext/src/ruby_api/convert.rs
+++ b/ext/src/ruby_api/convert.rs
@@ -1,8 +1,18 @@
-use crate::{err, error};
-use magnus::{Error, TypedData, Value};
+use crate::{define_rb_intern, err, error};
+use magnus::{Error, Symbol, TypedData, Value};
 use wasmtime::{ExternRef, Val, ValType};
 
 use super::{func::Func, memory::Memory, store::StoreContextValue};
+
+define_rb_intern!(
+    I32 => "i32",
+    I64 => "i64",
+    F32 => "f32",
+    F64 => "f64",
+    V128 => "v128",
+    FUNCREF => "funcref",
+    EXTERNREF => "externref",
+);
 
 pub trait ToRubyValue {
     fn to_ruby_value(&self, store: &StoreContextValue) -> Result<Value, Error>;
@@ -81,6 +91,60 @@ impl ToExtern for Value {
                 format!("unexpected extern: {}", self.inspect()),
             ))
         }
+    }
+}
+
+pub trait ToSym {
+    fn to_sym(self) -> Symbol;
+}
+
+impl ToSym for ValType {
+    fn to_sym(self) -> Symbol {
+        match self {
+            ValType::I32 => Symbol::from(*I32),
+            ValType::I64 => Symbol::from(*I64),
+            ValType::F32 => Symbol::from(*F32),
+            ValType::F64 => Symbol::from(*F64),
+            ValType::V128 => Symbol::from(*V128),
+            ValType::FuncRef => Symbol::from(*FUNCREF),
+            ValType::ExternRef => Symbol::from(*EXTERNREF),
+        }
+    }
+}
+pub trait ToValType {
+    fn to_val_type(&self) -> Result<ValType, Error>;
+}
+
+impl ToValType for Value {
+    fn to_val_type(&self) -> Result<ValType, Error> {
+        if let Ok(symbol) = self.try_convert::<Symbol>() {
+            if let Ok(true) = symbol.equal(Symbol::from(*I32)) {
+                return Ok(ValType::I32);
+            }
+            if let Ok(true) = symbol.equal(Symbol::from(*I64)) {
+                return Ok(ValType::I64);
+            }
+            if let Ok(true) = symbol.equal(Symbol::from(*F32)) {
+                return Ok(ValType::F32);
+            }
+            if let Ok(true) = symbol.equal(Symbol::from(*F64)) {
+                return Ok(ValType::F64);
+            }
+            if let Ok(true) = symbol.equal(Symbol::from(*V128)) {
+                return Ok(ValType::V128);
+            }
+            if let Ok(true) = symbol.equal(Symbol::from(*FUNCREF)) {
+                return Ok(ValType::FuncRef);
+            }
+            if let Ok(true) = symbol.equal(Symbol::from(*EXTERNREF)) {
+                return Ok(ValType::ExternRef);
+            }
+        }
+
+        err!(
+            "invalid Webassembly type, expected one of [:i32, :i64, :f32, :f64, :v128, :funcref, :externref], got {:}",
+            self.inspect()
+        )
     }
 }
 

--- a/ext/src/ruby_api/convert.rs
+++ b/ext/src/ruby_api/convert.rs
@@ -29,7 +29,7 @@ impl ToRubyValue for Val {
                 None => Ok(magnus::QNIL.into()),
                 Some(eref) => eref
                     .data()
-                    .downcast_ref::<RbExternRef>()
+                    .downcast_ref::<ExternRefValue>()
                     .map(|v| v.0)
                     .ok_or_else(|| error!("failed to extract externref")),
             },
@@ -55,7 +55,7 @@ impl ToWasmVal for Value {
             ValType::ExternRef => {
                 let extern_ref_value = match self.is_nil() {
                     true => None,
-                    false => Some(ExternRef::new(RbExternRef::from(*self))),
+                    false => Some(ExternRef::new(ExternRefValue::from(*self))),
                 };
 
                 Ok(Val::ExternRef(extern_ref_value))
@@ -72,14 +72,14 @@ impl ToWasmVal for Value {
     }
 }
 
-struct RbExternRef(Value);
-impl From<Value> for RbExternRef {
+struct ExternRefValue(Value);
+impl From<Value> for ExternRefValue {
     fn from(v: Value) -> Self {
         Self(v)
     }
 }
-unsafe impl Send for RbExternRef {}
-unsafe impl Sync for RbExternRef {}
+unsafe impl Send for ExternRefValue {}
+unsafe impl Sync for ExternRefValue {}
 
 pub trait ToExtern {
     fn to_extern(&self) -> Result<wasmtime::Extern, Error>;
@@ -148,7 +148,7 @@ impl ToValType for Value {
         }
 
         err!(
-            "invalid Webassembly type, expected one of [:i32, :i64, :f32, :f64, :v128, :funcref, :externref], got {:}",
+            "invalid WebAssembly type, expected one of [:i32, :i64, :f32, :f64, :v128, :funcref, :externref], got {:}",
             self.inspect()
         )
     }

--- a/ext/src/ruby_api/func_type.rs
+++ b/ext/src/ruby_api/func_type.rs
@@ -1,17 +1,9 @@
-use super::root;
-use crate::{define_rb_intern, err};
-use magnus::{function, method, Error, Module as _, Object, RArray, Symbol, Value};
+use super::{
+    convert::{ToSym, ToValType},
+    root,
+};
+use magnus::{function, method, Error, Module as _, Object, RArray, Symbol};
 use wasmtime::{FuncType as FuncTypeImpl, ValType};
-
-define_rb_intern!(
-    I32 => "i32",
-    I64 => "i64",
-    F32 => "f32",
-    F64 => "f64",
-    V128 => "v128",
-    FUNCREF => "funcref",
-    EXTERNREF => "externref",
-);
 
 /// @yard
 /// Represents a Func's signature.
@@ -60,43 +52,6 @@ impl FuncType {
     }
 }
 
-trait ToValType {
-    fn to_val_type(&self) -> Result<ValType, Error>;
-}
-
-impl ToValType for Value {
-    fn to_val_type(&self) -> Result<ValType, Error> {
-        if let Ok(symbol) = self.try_convert::<Symbol>() {
-            if let Ok(true) = symbol.equal(Symbol::from(*I32)) {
-                return Ok(ValType::I32);
-            }
-            if let Ok(true) = symbol.equal(Symbol::from(*I64)) {
-                return Ok(ValType::I64);
-            }
-            if let Ok(true) = symbol.equal(Symbol::from(*F32)) {
-                return Ok(ValType::F32);
-            }
-            if let Ok(true) = symbol.equal(Symbol::from(*F64)) {
-                return Ok(ValType::F64);
-            }
-            if let Ok(true) = symbol.equal(Symbol::from(*V128)) {
-                return Ok(ValType::V128);
-            }
-            if let Ok(true) = symbol.equal(Symbol::from(*FUNCREF)) {
-                return Ok(ValType::FuncRef);
-            }
-            if let Ok(true) = symbol.equal(Symbol::from(*EXTERNREF)) {
-                return Ok(ValType::ExternRef);
-            }
-        }
-
-        err!(
-            "invalid Webassembly type, expected one of [:i32, :i64, :f32, :f64, :v128, :funcref, :externref], got {:}",
-            self.inspect()
-        )
-    }
-}
-
 trait ToValTypeVec {
     fn to_val_type_vec(&self) -> Result<Vec<ValType>, Error>;
 }
@@ -107,24 +62,6 @@ impl ToValTypeVec for RArray {
             .iter()
             .map(ToValType::to_val_type)
             .collect::<Result<Vec<ValType>, Error>>()
-    }
-}
-
-trait ToSym {
-    fn to_sym(self) -> Symbol;
-}
-
-impl ToSym for ValType {
-    fn to_sym(self) -> Symbol {
-        match self {
-            ValType::I32 => Symbol::from(*I32),
-            ValType::I64 => Symbol::from(*I64),
-            ValType::F32 => Symbol::from(*F32),
-            ValType::F64 => Symbol::from(*F64),
-            ValType::V128 => Symbol::from(*V128),
-            ValType::FuncRef => Symbol::from(*FUNCREF),
-            ValType::ExternRef => Symbol::from(*EXTERNREF),
-        }
     }
 }
 

--- a/ext/src/ruby_api/instance.rs
+++ b/ext/src/ruby_api/instance.rs
@@ -44,7 +44,7 @@ impl Instance {
         let (s, module) = args.required;
         let wrapped_store: WrappedStruct<Store> = s.try_convert()?;
         let store = wrapped_store.get()?;
-        let context = store.context_mut();
+        let mut context = store.context_mut();
         let imports = args
             .optional
             .0
@@ -56,7 +56,7 @@ impl Instance {
                 let mut imports = Vec::with_capacity(arr.len());
                 for import in arr.each() {
                     let import = import?;
-                    store.retain(import);
+                    context.data_mut().retain(import);
                     imports.push(import.to_extern()?);
                 }
                 imports

--- a/ext/src/ruby_api/memory.rs
+++ b/ext/src/ruby_api/memory.rs
@@ -29,6 +29,7 @@ unsafe impl TypedData for Memory<'_> {
         memoize!(magnus::DataType: {
             let mut builder = DataTypeBuilder::<Memory<'_>>::new("Wasmtime::Memory");
             builder.free_immediately();
+            builder.mark();
             builder.build()
         })
     }

--- a/ext/src/ruby_api/mod.rs
+++ b/ext/src/ruby_api/mod.rs
@@ -20,6 +20,8 @@ mod module;
 mod params;
 mod static_id;
 mod store;
+mod table;
+mod table_type;
 mod trap;
 mod wasi_ctx_builder;
 
@@ -64,6 +66,8 @@ pub fn init() -> Result<(), Error> {
     linker::init()?;
     externals::init()?;
     wasi_ctx_builder::init()?;
+    table::init()?;
+    table_type::init()?;
 
     Ok(())
 }

--- a/ext/src/ruby_api/store.rs
+++ b/ext/src/ruby_api/store.rs
@@ -247,6 +247,11 @@ impl<'a> StoreContextValue<'a> {
             Err(e) => e,
         }
     }
+
+    pub fn retain(&self, value: Value) -> Result<(), Error> {
+        self.context_mut()?.data_mut().retain(value);
+        Ok(())
+    }
 }
 
 pub fn init() -> Result<(), Error> {

--- a/ext/src/ruby_api/table.rs
+++ b/ext/src/ruby_api/table.rs
@@ -64,7 +64,7 @@ impl<'a> Table<'a> {
             inner,
         };
 
-        table.retain_extern_ref(default)?;
+        table.retain_non_nil_extern_ref(default)?;
 
         Ok(table)
     }
@@ -102,7 +102,7 @@ impl<'a> Table<'a> {
             )
             .map_err(|e| error!("{}", e))
             .and_then(|result| {
-                self.retain_extern_ref(value)?;
+                self.retain_non_nil_extern_ref(value)?;
                 Ok(result)
             })
     }
@@ -124,7 +124,7 @@ impl<'a> Table<'a> {
             )
             .map_err(|e| error!("{}", e))
             .and_then(|result| {
-                self.retain_extern_ref(initial)?;
+                self.retain_non_nil_extern_ref(initial)?;
                 Ok(result)
             })
     }
@@ -145,7 +145,7 @@ impl<'a> Table<'a> {
         Ok(self.inner.ty(self.store.context()?).element())
     }
 
-    fn retain_extern_ref(&self, value: Value) -> Result<(), Error> {
+    fn retain_non_nil_extern_ref(&self, value: Value) -> Result<(), Error> {
         if wasmtime::ValType::ExternRef == self.value_type()? && !value.is_nil() {
             self.store.retain(value)?;
         }

--- a/ext/src/ruby_api/table.rs
+++ b/ext/src/ruby_api/table.rs
@@ -69,6 +69,10 @@ impl<'a> Table<'a> {
         Ok(table)
     }
 
+    pub fn from_inner(store: StoreContextValue<'a>, inner: TableImpl) -> Self {
+        Self { store, inner }
+    }
+
     /// @yard
     /// Returns the table element value at +index+, or +nil+ if index is out of bound.
     ///

--- a/ext/src/ruby_api/table.rs
+++ b/ext/src/ruby_api/table.rs
@@ -1,0 +1,162 @@
+use super::{
+    convert::{ToRubyValue, ToWasmVal},
+    root,
+    store::{Store, StoreContextValue},
+    table_type::TableType,
+};
+use crate::{error, helpers::WrappedStruct};
+use magnus::{
+    function, memoize, method, r_typed_data::DataTypeBuilder, DataTypeFunctions, Error,
+    Module as _, Object, RClass, TypedData, Value, QNIL,
+};
+use wasmtime::Table as TableImpl;
+
+/// @yard
+/// @rename Wasmtime::Table
+/// Represents a WebAssembly table.
+/// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Table.html Wasmtime's Rust doc
+#[derive(Debug)]
+pub struct Table<'a> {
+    store: StoreContextValue<'a>,
+    inner: TableImpl,
+}
+
+unsafe impl TypedData for Table<'_> {
+    fn class() -> magnus::RClass {
+        *memoize!(RClass: root().define_class("Table", Default::default()).unwrap())
+    }
+
+    fn data_type() -> &'static magnus::DataType {
+        memoize!(magnus::DataType: {
+            let mut builder = DataTypeBuilder::<Table<'_>>::new("Wasmtime::Table");
+            builder.free_immediately();
+            builder.mark();
+            builder.build()
+        })
+    }
+}
+
+impl DataTypeFunctions for Table<'_> {
+    fn mark(&self) {
+        self.store.mark()
+    }
+}
+
+impl<'a> Table<'a> {
+    /// @yard
+    /// @def new(store, tabletype, initial)
+    /// @param store [Store]
+    /// @param tabletype [TableType]
+    /// @param initial [Value] The initial value for values in the table.
+    pub fn new(
+        s: WrappedStruct<Store>,
+        tabletype: &TableType,
+        default: Value,
+    ) -> Result<Self, Error> {
+        let store = s.get()?;
+        let default_val = default.to_wasm_val(&tabletype.get().element())?;
+
+        let inner = TableImpl::new(store.context_mut(), tabletype.get().clone(), default_val)
+            .map_err(|e| error!("{}", e))?;
+
+        let table = Self {
+            store: s.into(),
+            inner,
+        };
+
+        table.retain_extern_ref(default)?;
+
+        Ok(table)
+    }
+
+    /// @yard
+    /// Returns the table element value at +index+, or +nil+ if index is out of bound.
+    ///
+    /// @def get(index)
+    /// @param index [Integer]
+    /// @return [Object, nil]
+    pub fn get(&self, index: u32) -> Result<Value, Error> {
+        match self.inner.get(self.store.context_mut()?, index) {
+            Some(wasm_val) => wasm_val.to_ruby_value(&self.store),
+            None => Ok(*QNIL),
+        }
+    }
+
+    /// @yard
+    /// Sets the table entry at +index+ to +value+.
+    ///
+    /// @def set(index, value)
+    /// @param index [Integer]
+    /// @param value [Object]
+    /// @return [void]
+    pub fn set(&self, index: u32, value: Value) -> Result<(), Error> {
+        self.inner
+            .set(
+                self.store.context_mut()?,
+                index,
+                value.to_wasm_val(&self.value_type()?)?,
+            )
+            .map_err(|e| error!("{}", e))
+            .and_then(|result| {
+                self.retain_extern_ref(value)?;
+                Ok(result)
+            })
+    }
+
+    /// @yard
+    /// Grows the size of this table by +delta+.
+    /// Raises if the table grows beyond its limit.
+    ///
+    /// @def grow(delta, initial)
+    /// @param delta [Integer] The number of elements to add to the table.
+    /// @param initial [Object] The initial value for newly added table slots.
+    /// @return [void]
+    pub fn grow(&self, delta: u32, initial: Value) -> Result<u32, Error> {
+        self.inner
+            .grow(
+                self.store.context_mut()?,
+                delta,
+                initial.to_wasm_val(&self.value_type()?)?,
+            )
+            .map_err(|e| error!("{}", e))
+            .and_then(|result| {
+                self.retain_extern_ref(initial)?;
+                Ok(result)
+            })
+    }
+
+    /// @yard
+    /// @return [Integer] The size of the table.
+    pub fn size(&self) -> Result<u32, Error> {
+        Ok(self.inner.size(self.store.context()?))
+    }
+
+    /// @yard
+    /// @return [TableType]
+    pub fn ty(&self) -> Result<TableType, Error> {
+        Ok(self.inner.ty(self.store.context()?).into())
+    }
+
+    fn value_type(&self) -> Result<wasmtime::ValType, Error> {
+        Ok(self.inner.ty(self.store.context()?).element())
+    }
+
+    fn retain_extern_ref(&self, value: Value) -> Result<(), Error> {
+        if wasmtime::ValType::ExternRef == self.value_type()? && !value.is_nil() {
+            self.store.retain(value)?;
+        }
+        Ok(())
+    }
+}
+
+pub fn init() -> Result<(), Error> {
+    let class = root().define_class("Table", Default::default())?;
+    class.define_singleton_method("new", function!(Table::new, 3))?;
+    class.define_method("get", method!(Table::get, 1))?;
+    class.define_method("set", method!(Table::set, 2))?;
+    class.define_method("grow", method!(Table::grow, 2))?;
+    class.define_method("size", method!(Table::size, 0))?;
+    class.define_method("ty", method!(Table::ty, 0))?;
+
+    Ok(())
+}

--- a/ext/src/ruby_api/table_type.rs
+++ b/ext/src/ruby_api/table_type.rs
@@ -1,0 +1,67 @@
+use super::{
+    convert::{ToSym, ToValType},
+    root,
+};
+use magnus::{function, method, scan_args, Error, Module as _, Object, Symbol, Value};
+use wasmtime::TableType as TableTypeImpl;
+
+/// @yard
+/// @see https://docs.rs/wasmtime/latest/wasmtime/struct.TableType.html Wasmtime's Rust doc
+#[derive(Clone, Debug)]
+#[magnus::wrap(class = "Wasmtime::TableType")]
+pub struct TableType {
+    inner: TableTypeImpl,
+}
+
+impl TableType {
+    /// @yard
+    /// @def new(element, min, max = nil)
+    /// @param element [Symbol] The type of the elements in the {Table}.
+    /// @param min [Integer] The minimum {Table} size.
+    /// @param max [Integer, nil] The maximum {Table} size.
+    pub fn new(args: &[Value]) -> Result<Self, Error> {
+        let args = scan_args::scan_args::<(Value, u32), (Option<u32>,), (), (), (), ()>(args)?;
+        let (ty, min) = args.required;
+        let (max,) = args.optional;
+        let inner = TableTypeImpl::new(ty.to_val_type()?, min, max);
+        Ok(Self { inner })
+    }
+
+    pub fn get(&self) -> &TableTypeImpl {
+        &self.inner
+    }
+
+    /// @yard
+    /// @return [Symbol] The type of elements in the {Table}.
+    pub fn element(&self) -> Symbol {
+        self.inner.element().to_sym()
+    }
+
+    /// @yard
+    /// @return [Integer] The minimum size of the {Table}.
+    pub fn minimum(&self) -> u32 {
+        self.inner.minimum()
+    }
+
+    /// @yard
+    /// @return [Integer, nil] The maximum size of the {Table}.
+    pub fn maximum(&self) -> Option<u32> {
+        self.inner.maximum()
+    }
+}
+
+pub fn init() -> Result<(), Error> {
+    let class = root().define_class("TableType", Default::default())?;
+
+    class.define_singleton_method("new", function!(TableType::new, -1))?;
+    class.define_method("element", method!(TableType::element, 0))?;
+    class.define_method("minimum", method!(TableType::minimum, 0))?;
+    class.define_method("maximum", method!(TableType::maximum, 0))?;
+    Ok(())
+}
+
+impl From<TableTypeImpl> for TableType {
+    fn from(inner: TableTypeImpl) -> Self {
+        Self { inner }
+    }
+}

--- a/spec/unit/extern_spec.rb
+++ b/spec/unit/extern_spec.rb
@@ -4,7 +4,8 @@ module Wasmtime
   RSpec.describe Extern do
     cases = {
       f: [:to_func, Func],
-      m: [:to_memory, Memory]
+      m: [:to_memory, Memory],
+      t: [:to_table, Table]
     }
 
     cases.each do |name, (meth, klass)|
@@ -41,6 +42,7 @@ module Wasmtime
         (module
           (func (export "f"))
           (memory (export "m") 1)
+          (table (export "t") 1 funcref)
         )
       WAT
     end

--- a/spec/unit/func_spec.rb
+++ b/spec/unit/func_spec.rb
@@ -73,6 +73,7 @@ module Wasmtime
             (import "" "" (func))
             (memory (export "mem") 1)
             (export "f1_export" (func 1))
+            (table (export "table") 1 funcref)
             (start 0))
         WAT
         store = Store.new(engine)
@@ -92,6 +93,9 @@ module Wasmtime
 
           f1_export = caller.export("f1_export").to_func
           f1_export.call
+
+          table_export = caller.export("table").to_table
+          expect(table_export).to be_instance_of(Table)
         end
         f1 = Func.new(store, FuncType.new([], [])) { calls += 1 }
 

--- a/spec/unit/table_spec.rb
+++ b/spec/unit/table_spec.rb
@@ -1,0 +1,116 @@
+require "spec_helper"
+
+module Wasmtime
+  RSpec.describe Table do
+    describe ".new" do
+      it "creates a table with no default" do
+        table = Table.new(store, TableType.new(:funcref, 1), nil)
+        expect(table).to be_instance_of(Wasmtime::Table)
+      end
+
+      it "creates a table with default func" do
+        table = Table.new(store, TableType.new(:funcref, 1), noop_func)
+        expect(table).to be_instance_of(Wasmtime::Table)
+      end
+    end
+
+    describe "#size" do
+      it "returns its size" do
+        table = Table.new(store, TableType.new(:funcref, 1), nil)
+        expect(table.size).to eq(1)
+      end
+    end
+
+    describe "#ty" do
+      it "returns its table type" do
+        table = Table.new(store, TableType.new(:funcref, 1), nil)
+        expect(table.ty).to be_instance_of(TableType)
+        expect(table.ty.minimum).to eq(1)
+        expect(table.ty.maximum).to be_nil
+      end
+    end
+
+    describe "#grow" do
+      it "increases the size" do
+        table = Table.new(store, TableType.new(:funcref, 1), nil)
+        expect { table.grow(2, nil) }.to change { table.size }.by(2)
+      end
+
+      it "returns the previous size" do
+        table = Table.new(store, TableType.new(:funcref, 1), nil)
+        expect(table.grow(1, nil)).to eq(1)
+      end
+
+      it "raises when growing past the maximum" do
+        table = Table.new(store, TableType.new(:funcref, 1, 1), nil)
+        expect { table.grow(1, nil) }.to raise_error(Wasmtime::Error, "failed to grow table by `1`")
+      end
+    end
+
+    describe "#get" do
+      it "returns a Func" do
+        table = Table.new(store, TableType.new(:funcref, 1), noop_func)
+        expect(table.get(0)).to be_instance_of(Func)
+      end
+
+      it "returns an externref" do
+        value = BasicObject.new
+        table = Table.new(store, TableType.new(:externref, 1), value)
+        expect(table.get(0)).to eq(value)
+      end
+
+      it "returns nil for null ref" do
+        table = Table.new(store, TableType.new(:funcref, 1), nil)
+        expect(table.get(0)).to be_nil
+      end
+
+      it "returns nil for out of bound" do
+        table = Table.new(store, TableType.new(:funcref, 1), noop_func)
+        expect(table.get(5)).to be_nil
+      end
+    end
+
+    describe "#set" do
+      it "writes nil" do
+        table = Table.new(store, TableType.new(:funcref, 1), noop_func)
+        table.set(0, nil)
+        expect(table.get(0)).to be_nil
+      end
+
+      it "writes a Func" do
+        table = Table.new(store, TableType.new(:funcref, 1), noop_func)
+        table.set(0, noop_func)
+        expect(table.get(0)).to be_instance_of(Func)
+      end
+
+      it "rejects invalid type" do
+        table = Table.new(store, TableType.new(:funcref, 1), noop_func)
+        expect { table.set(0, 1) }.to raise_error(TypeError)
+      end
+    end
+
+    it "keeps externrefs alive" do
+      table = Table.new(store, TableType.new(:externref, 2), +"foo")
+      generate_new_objects
+      expect(table.get(0)).to eq("foo")
+
+      table.set(1, +"bar")
+      generate_new_objects
+      expect(table.get(1)).to eq("bar")
+
+      table.grow(1, +"baz")
+      generate_new_objects
+      expect(table.get(2)).to eq("baz")
+    end
+
+    private
+
+    def noop_func
+      Func.new(store, FuncType.new([], [])) { |_| }
+    end
+
+    def generate_new_objects
+      "hi" * 3
+    end
+  end
+end

--- a/spec/unit/table_type_spec.rb
+++ b/spec/unit/table_type_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+module Wasmtime
+  RSpec.describe TableType do
+    it "creates a table type with min and max" do
+      type = TableType.new(:funcref, 1, 2)
+      expect(type.element).to eq(:funcref)
+      expect(type.minimum).to eq(1)
+      expect(type.maximum).to eq(2)
+    end
+
+    it "creates a table type without maximum" do
+      type = TableType.new(:funcref, 1)
+      expect(type.minimum).to eq(1)
+      expect(type.maximum).to be_nil
+    end
+
+    it "raises on invalid Wasm type" do
+      expect { TableType.new(:nope, 1) }
+        .to raise_error(Wasmtime::Error, /invalid Webassembly type/)
+    end
+  end
+end

--- a/spec/unit/table_type_spec.rb
+++ b/spec/unit/table_type_spec.rb
@@ -17,7 +17,7 @@ module Wasmtime
 
     it "raises on invalid Wasm type" do
       expect { TableType.new(:nope, 1) }
-        .to raise_error(Wasmtime::Error, /invalid Webassembly type/)
+        .to raise_error(Wasmtime::Error, /invalid WebAssembly type/)
     end
   end
 end


### PR DESCRIPTION
Add support for Wasm tables. Fixes #20.

The first 2 commits are refactors:
1. Move `ToValType` to `convert` as we'll need it not only for Funcs.

2. Move `refs` from `Store` to `StoreData` so it's accessible for both `Store` and `Caller`. This is we have a way of GC marking the extern refs we store in the `Table`.
    
    Storing on the (Ruby) `Table` itself won't work because the user can drop their reference to `Table`, but we must still keep marking whatever they stored in the Table otherwise we could segfault or have data corruption.

The other commits implement tables.