### PR TITLE
Add benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Run examples
         run: bundle exec rake examples
 
+      - name: Run benchmarks
+        run: bundle exec rake bench:all
+
       - name: Lint ruby
         run: bundle exec rake standard
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ group :development do
   gem "ruby-lsp", require: false
   gem "yard", require: false
   gem "yard-rustdoc", "~> 0.3.2", require: false
+  gem "benchmark-ips", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    benchmark-ips (2.10.0)
     diff-lcs (1.5.0)
     ffi (1.15.5)
     ffi (1.15.5-x64-mingw-ucrt)
@@ -84,6 +85,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  benchmark-ips
   get_process_mem
   rake (~> 13.0)
   rake-compiler

--- a/bench/bench.rb
+++ b/bench/bench.rb
@@ -1,0 +1,14 @@
+require "benchmark/ips"
+require "wasmtime"
+
+module Bench
+  extend(self)
+
+  def ips
+    Benchmark.ips do |x|
+      yield(x)
+
+      x.config(time: 0, warmup: 0) if ENV["CI"]
+    end
+  end
+end

--- a/bench/compile.rb
+++ b/bench/compile.rb
@@ -1,0 +1,9 @@
+require_relative "bench"
+
+Bench.ips do |x|
+  engine = Wasmtime::Engine.new
+
+  x.report("empty module") do
+    Wasmtime::Module.new(engine, "(module)")
+  end
+end

--- a/bench/func_call.rb
+++ b/bench/func_call.rb
@@ -1,0 +1,19 @@
+require_relative "bench"
+
+Bench.ips do |x|
+  engine = Wasmtime::Engine.new
+  linker = Wasmtime::Linker.new(engine)
+  mod = Wasmtime::Module.from_file(engine, "examples/gcd.wat")
+
+  x.report("Instance#invoke") do
+    store = Wasmtime::Store.new(engine)
+    linker.instantiate(store, mod).invoke("gcd", 5, 1)
+  end
+
+  x.report("Func#call") do
+    store = Wasmtime::Store.new(engine)
+    linker.instantiate(store, mod).export("gcd").to_func.call(5, 1)
+  end
+
+  x.compare!
+end

--- a/bench/host_call.rb
+++ b/bench/host_call.rb
@@ -1,0 +1,21 @@
+require_relative "bench"
+
+Bench.ips do |x|
+  engine = Wasmtime::Engine.new
+  mod = Wasmtime::Module.new(engine, <<~WAT)
+    (module
+      (import "host" "succ" (func (param i32) (result i32)))
+      (export "run" (func 0)))
+  WAT
+  linker = Wasmtime::Linker.new(engine)
+  linker.func_new("host", "succ", Wasmtime::FuncType.new([:i32], [:i32])) do |_caller, arg1|
+    arg1.succ
+  end
+
+  x.report("Call host func") do
+    store = Wasmtime::Store.new(engine)
+    linker.instantiate(store, mod).invoke("run", 101)
+  end
+
+  x.compare!
+end

--- a/bench/instantiate.rb
+++ b/bench/instantiate.rb
@@ -1,0 +1,19 @@
+require_relative "bench"
+
+Bench.ips do |x|
+  engine = Wasmtime::Engine.new
+  linker = Wasmtime::Linker.new(engine)
+  mod = Wasmtime::Module.new(engine, "(module)")
+
+  x.report("Linker#instantiate") do
+    store = Wasmtime::Store.new(engine)
+    linker.instantiate(store, mod)
+  end
+
+  x.report("Instance#new") do
+    store = Wasmtime::Store.new(engine)
+    Wasmtime::Instance.new(store, mod)
+  end
+
+  x.compare!
+end

--- a/rakelib/bench.rake
+++ b/rakelib/bench.rake
@@ -1,0 +1,18 @@
+namespace :bench do
+  task all: :compile
+
+  Dir.glob("bench/*.rb").each do |path|
+    task_name = File.basename(path, ".rb")
+
+    desc "Run #{path} benchmark"
+    task task_name do
+      sh "ruby -Ilib #{path}"
+      puts
+    end
+
+    task all: task_name
+  end
+end
+
+desc "Run all benchmarks"
+task bench: "bench:all"


### PR DESCRIPTION
Initial benchmark suite. They're not the most helpful benchmarks for now, but just having them there will make it easier to try out optimizations.

Just like examples, I figured we should run them on CI to make sure they're still valid. But... faster, so we don't spend 5+s on each thing we're benchmarking.