### PR TITLE
Add global support

### DIFF
--- a/ext/src/ruby_api/convert.rs
+++ b/ext/src/ruby_api/convert.rs
@@ -2,7 +2,7 @@ use crate::{define_rb_intern, err, error};
 use magnus::{Error, Symbol, TypedData, Value};
 use wasmtime::{ExternRef, Val, ValType};
 
-use super::{func::Func, memory::Memory, store::StoreContextValue, table::Table};
+use super::{func::Func, global::Global, memory::Memory, store::StoreContextValue, table::Table};
 
 define_rb_intern!(
     I32 => "i32",
@@ -93,6 +93,8 @@ impl ToExtern for Value {
             Ok(self.try_convert::<&Memory>()?.into())
         } else if self.is_kind_of(Table::class()) {
             Ok(self.try_convert::<&Table>()?.into())
+        } else if self.is_kind_of(Global::class()) {
+            Ok(self.try_convert::<&Global>()?.into())
         } else {
             Err(Error::new(
                 magnus::exception::type_error(),

--- a/ext/src/ruby_api/global.rs
+++ b/ext/src/ruby_api/global.rs
@@ -1,0 +1,141 @@
+use super::{
+    convert::{ToRubyValue, ToWasmVal},
+    global_type::GlobalType,
+    root,
+    store::{Store, StoreContextValue},
+};
+use crate::{error, helpers::WrappedStruct};
+use magnus::{
+    function, memoize, method, r_typed_data::DataTypeBuilder, DataTypeFunctions, Error,
+    Module as _, Object, RClass, TypedData, Value,
+};
+use wasmtime::{Extern, Global as GlobalImpl};
+
+/// @yard
+/// @rename Wasmtime::Global
+/// Represents a WebAssembly global.
+/// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Global.html Wasmtime's Rust doc
+#[derive(Debug)]
+pub struct Global<'a> {
+    store: StoreContextValue<'a>,
+    inner: GlobalImpl,
+}
+
+unsafe impl TypedData for Global<'_> {
+    fn class() -> magnus::RClass {
+        *memoize!(RClass: root().define_class("Global", Default::default()).unwrap())
+    }
+
+    fn data_type() -> &'static magnus::DataType {
+        memoize!(magnus::DataType: {
+            let mut builder = DataTypeBuilder::<Global<'_>>::new("Wasmtime::Global");
+            builder.free_immediately();
+            builder.mark();
+            builder.build()
+        })
+    }
+}
+
+impl DataTypeFunctions for Global<'_> {
+    fn mark(&self) {
+        self.store.mark()
+    }
+}
+
+impl<'a> Global<'a> {
+    /// @yard
+    /// @def new(store, globaltype, value)
+    /// @param store [Store]
+    /// @param globaltype [GlobalType]
+    /// @param value [Object] The value of the global.
+    pub fn new(
+        s: WrappedStruct<Store>,
+        globaltype: &GlobalType,
+        value: Value,
+    ) -> Result<Self, Error> {
+        let store = s.get()?;
+
+        let inner = GlobalImpl::new(
+            store.context_mut(),
+            globaltype.get().clone(),
+            value.to_wasm_val(globaltype.get().content())?,
+        )
+        .map_err(|e| error!("{}", e))?;
+
+        let global = Self {
+            store: s.into(),
+            inner,
+        };
+
+        global.retain_non_nil_extern_ref(value)?;
+
+        Ok(global)
+    }
+
+    pub fn from_inner(store: StoreContextValue<'a>, inner: GlobalImpl) -> Self {
+        Self { store, inner }
+    }
+
+    /// @yard
+    /// @return [Object] The current value of the global.
+    pub fn get(&self) -> Result<Value, Error> {
+        self.inner
+            .get(self.store.context_mut()?)
+            .to_ruby_value(&self.store)
+    }
+
+    /// @yard
+    /// Sets the value of the global. Raises if the global is a +const+.
+    /// @def set(value)
+    /// @param value [Object] An object that can be converted to the global's type.
+    /// @return [nil]
+    pub fn set(&self, value: Value) -> Result<(), Error> {
+        self.inner
+            .set(
+                self.store.context_mut()?,
+                value.to_wasm_val(&self.value_type()?)?,
+            )
+            .map_err(|e| error!("{}", e))
+            .and_then(|result| {
+                self.retain_non_nil_extern_ref(value)?;
+                Ok(result)
+            })
+    }
+
+    /// @yard
+    /// @return [GlobalType]
+    pub fn ty(&self) -> Result<GlobalType, Error> {
+        Ok(self.inner.ty(self.store.context()?).into())
+    }
+
+    fn value_type(&self) -> Result<wasmtime::ValType, Error> {
+        Ok(self.inner.ty(self.store.context()?).content().clone())
+    }
+
+    fn retain_non_nil_extern_ref(&self, value: Value) -> Result<(), Error> {
+        if wasmtime::ValType::ExternRef == self.value_type()? && !value.is_nil() {
+            self.store.retain(value)?;
+        }
+        Ok(())
+    }
+
+    pub fn inner(&self) -> GlobalImpl {
+        self.inner
+    }
+}
+
+impl From<&Global<'_>> for Extern {
+    fn from(global: &Global) -> Self {
+        Self::Global(global.inner())
+    }
+}
+
+pub fn init() -> Result<(), Error> {
+    let class = root().define_class("Global", Default::default())?;
+    class.define_singleton_method("new", function!(Global::new, 3))?;
+    class.define_method("get", method!(Global::get, 0))?;
+    class.define_method("set", method!(Global::set, 1))?;
+    class.define_method("ty", method!(Global::ty, 0))?;
+
+    Ok(())
+}

--- a/ext/src/ruby_api/global_type.rs
+++ b/ext/src/ruby_api/global_type.rs
@@ -1,0 +1,79 @@
+use super::{
+    convert::{ToSym, ToValType},
+    root,
+};
+use magnus::{function, method, Error, Module as _, Object, Symbol};
+use wasmtime::{GlobalType as GlobalTypeImpl, Mutability};
+
+/// @yard
+/// @see https://docs.rs/wasmtime/latest/wasmtime/struct.GlobalType.html Wasmtime's Rust doc
+#[derive(Clone, Debug)]
+#[magnus::wrap(class = "Wasmtime::GlobalType")]
+pub struct GlobalType {
+    inner: GlobalTypeImpl,
+}
+
+impl GlobalType {
+    /// @yard
+    /// @def const(content)
+    /// @param content [Symbol] The type of {Global}‘s content.
+    /// @return [GlobalType] A constant GlobalType.
+    pub fn const_(content: Symbol) -> Result<Self, Error> {
+        Self::new(content, Mutability::Const)
+    }
+
+    /// @yard
+    /// @def var(content)
+    /// @param content [Symbol] The type of {Global}‘s content.
+    /// @return [GlobalType] A variable GlobalType.
+    pub fn var(content: Symbol) -> Result<Self, Error> {
+        Self::new(content, Mutability::Var)
+    }
+
+    /// @yard
+    /// @def const?
+    /// @return [Boolean]
+    pub fn is_const(&self) -> bool {
+        self.inner.mutability() == Mutability::Const
+    }
+
+    /// @yard
+    /// @def var?
+    /// @return [Boolean]
+    pub fn is_var(&self) -> bool {
+        self.inner.mutability() == Mutability::Var
+    }
+
+    /// @yard
+    /// @return [Symbol] The Wasm type of the {Global}‘s content.
+    pub fn content(&self) -> Symbol {
+        self.inner.content().clone().to_sym()
+    }
+
+    pub fn get(&self) -> &GlobalTypeImpl {
+        &self.inner
+    }
+
+    fn new(content: Symbol, mutability: Mutability) -> Result<Self, Error> {
+        let inner = GlobalTypeImpl::new(content.to_val_type()?, mutability);
+
+        Ok(Self { inner })
+    }
+}
+
+pub fn init() -> Result<(), Error> {
+    let class = root().define_class("GlobalType", Default::default())?;
+
+    class.define_singleton_method("const", function!(GlobalType::const_, 1))?;
+    class.define_singleton_method("var", function!(GlobalType::var, 1))?;
+    class.define_method("const?", method!(GlobalType::is_const, 0))?;
+    class.define_method("var?", method!(GlobalType::is_var, 0))?;
+    class.define_method("content", method!(GlobalType::content, 0))?;
+    Ok(())
+}
+
+impl From<GlobalTypeImpl> for GlobalType {
+    fn from(inner: GlobalTypeImpl) -> Self {
+        Self { inner }
+    }
+}

--- a/ext/src/ruby_api/mod.rs
+++ b/ext/src/ruby_api/mod.rs
@@ -11,6 +11,7 @@ mod errors;
 mod externals;
 mod func;
 mod func_type;
+mod global_type;
 mod instance;
 mod linker;
 mod macros;
@@ -68,6 +69,7 @@ pub fn init() -> Result<(), Error> {
     wasi_ctx_builder::init()?;
     table::init()?;
     table_type::init()?;
+    global_type::init()?;
 
     Ok(())
 }

--- a/ext/src/ruby_api/mod.rs
+++ b/ext/src/ruby_api/mod.rs
@@ -11,6 +11,7 @@ mod errors;
 mod externals;
 mod func;
 mod func_type;
+mod global;
 mod global_type;
 mod instance;
 mod linker;
@@ -69,6 +70,7 @@ pub fn init() -> Result<(), Error> {
     wasi_ctx_builder::init()?;
     table::init()?;
     table_type::init()?;
+    global::init()?;
     global_type::init()?;
 
     Ok(())

--- a/spec/unit/extern_spec.rb
+++ b/spec/unit/extern_spec.rb
@@ -5,7 +5,8 @@ module Wasmtime
     cases = {
       f: [:to_func, Func],
       m: [:to_memory, Memory],
-      t: [:to_table, Table]
+      t: [:to_table, Table],
+      g: [:to_global, Global]
     }
 
     cases.each do |name, (meth, klass)|
@@ -43,6 +44,7 @@ module Wasmtime
           (func (export "f"))
           (memory (export "m") 1)
           (table (export "t") 1 funcref)
+          (global (export "g") (mut i32) (i32.const 1))
         )
       WAT
     end

--- a/spec/unit/global_spec.rb
+++ b/spec/unit/global_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+module Wasmtime
+  RSpec.describe Global do
+    describe ".new" do
+      it "creates a global" do
+        global = Global.new(store, GlobalType.const(:i32), 1)
+        expect(global).to be_instance_of(Wasmtime::Global)
+      end
+    end
+
+    describe "#get" do
+      it "returns the global value" do
+        global = Global.new(store, GlobalType.const(:i32), 1)
+        expect(global.get).to eq(1)
+      end
+    end
+
+    describe "#set" do
+      it "changes the value" do
+        global = Global.new(store, GlobalType.var(:i32), 1)
+        global.set(2)
+        expect(global.get).to eq(2)
+      end
+
+      it "raises when the global is constant" do
+        global = Global.new(store, GlobalType.const(:i32), 1)
+        expect { global.set(2) }
+          .to raise_error(Wasmtime::Error, "immutable global cannot be set")
+      end
+    end
+
+    describe "#ty" do
+      it "returns the global type" do
+        ty = Global.new(store, GlobalType.var(:i32), 1).ty
+        expect(ty).to be_instance_of(GlobalType)
+        expect(ty).to be_var
+        expect(ty.content).to eq(:i32)
+      end
+    end
+
+    it "keeps externrefs alive" do
+      global = Global.new(store, GlobalType.var(:externref), +"foo")
+      generate_new_objects
+      expect(global.get).to eq("foo")
+
+      global.set(+"bar")
+      generate_new_objects
+      expect(global.get).to eq("bar")
+    end
+
+    private
+
+    def generate_new_objects
+      "hi" * 3
+    end
+  end
+end

--- a/spec/unit/global_type_spec.rb
+++ b/spec/unit/global_type_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+module Wasmtime
+  RSpec.describe GlobalType do
+    describe ".const" do
+      it "creates a const global type" do
+        type = GlobalType.const(:i32)
+        expect(type).to be_const
+        expect(type).not_to be_var
+      end
+
+      it "raises on invalid Wasm type" do
+        expect { GlobalType.const(:nope) }
+          .to raise_error(Wasmtime::Error, /invalid WebAssembly type/)
+      end
+    end
+
+    describe ".var" do
+      it "creates a var global type" do
+        type = GlobalType.var(:i32)
+        expect(type).to be_var
+        expect(type).not_to be_const
+      end
+
+      it "raises on invalid Wasm type" do
+        expect { GlobalType.var(:nope) }
+          .to raise_error(Wasmtime::Error, /invalid WebAssembly type/)
+      end
+    end
+
+    describe "#content" do
+      it "returns the Wasm type as symbol" do
+        type = GlobalType.const(:i32)
+        expect(type.content).to eq(:i32)
+      end
+    end
+  end
+end

--- a/spec/unit/linker_spec.rb
+++ b/spec/unit/linker_spec.rb
@@ -63,6 +63,14 @@ module Wasmtime
         linker.define("mod", "table", table)
         expect(linker.get(store, "mod", "table").to_table).to be_instance_of(Table)
       end
+
+      it "accepts global" do
+        linker = new_linker
+        store = Store.new(engine)
+        global = Global.new(store, GlobalType.var(:i32), 1)
+        linker.define("mod", "glob", global)
+        expect(linker.get(store, "mod", "glob").to_global).to be_instance_of(Global)
+      end
     end
 
     describe "func_new" do


### PR DESCRIPTION
Fixes #19 

Add support for Wasm globals. Decisions worth validating:
1. For creating `GlobalType`s, I've chosen to define 2 constructors (`GlobalType.const` & `GlobalType.var`) instead of accepting mutability as an argument. It feels like a nicer UI, less error prone, and nothing precludes adding `.new` that takes a symbol argument if we ever need that.
2. Following [Wasmtime's naming](https://docs.rs/wasmtime/latest/wasmtime/struct.GlobalType.html#method.content), I'm calling a GlobalType Wasm type "content" (e.g. `GlobalType#content -> :i32`). This naming feels odd to me, but didn't want to diverge without a clear reason.

----

I'm looking into the memcheck failure but it does not look related to this PR, I can reproduce on main (edit: fix for memcheck in #75).