### PR TITLE
Attempt to fix memcheck

### DIFF
--- a/ext/src/ruby_api/instance.rs
+++ b/ext/src/ruby_api/instance.rs
@@ -54,9 +54,9 @@ impl Instance {
             Some(arr) => {
                 let arr: RArray = arr.try_convert()?;
                 let mut imports = Vec::with_capacity(arr.len());
-                for import in arr.each() {
-                    let import = import?;
-                    context.data_mut().retain(import);
+                // SAFETY: arr won't get gc'd (it's on the stack) and we don't mutate it.
+                for import in unsafe { arr.as_slice() } {
+                    context.data_mut().retain(*import);
                     imports.push(import.to_extern()?);
                 }
                 imports

--- a/ext/src/ruby_api/wasi_ctx_builder.rs
+++ b/ext/src/ruby_api/wasi_ctx_builder.rs
@@ -223,8 +223,9 @@ impl WasiCtxBuilder {
         }
 
         if let Some(args) = inner.args.as_ref() {
-            for item in args.each() {
-                let arg = item?.try_convert::<RString>()?;
+            // SAFETY: no gc can happen nor do we write to `args`.
+            for item in unsafe { args.as_slice() } {
+                let arg = item.try_convert::<RString>()?;
                 // SAFETY: &str copied before calling in to Ruby, no GC can happen before.
                 let arg = unsafe { arg.as_str() }?;
                 builder = builder.arg(arg).map_err(|e| error!("{}", e))?


### PR DESCRIPTION
I've narrowed the valgrind failures on main to the usage of `RArray::each`. I don't know why this is happening, though. I'm replacing by `RArray::as_lice` which is faster and works for our use case.