### PR TITLE
More examples

### DIFF
--- a/examples/epoch.rb
+++ b/examples/epoch.rb
@@ -1,0 +1,56 @@
+require "wasmtime"
+
+config = Wasmtime::Config.new
+config.epoch_interruption = true
+engine = Wasmtime::Engine.new(config)
+# Re-use fibonacci function from the Fuel example
+mod = Wasmtime::Module.from_file(engine, "examples/fuel.wat")
+store = Wasmtime::Store.new(engine)
+instance = Wasmtime::Instance.new(store, mod)
+
+# Store starts with an epoch deadline of 0, meaning Wasm execution
+# will be halted right away.
+puts "Running Wasm with default epoch deadline of 0..."
+begin
+  instance.invoke("fibonacci", 5)
+  raise "Unexpected: Wasm executed past deadline"
+rescue Wasmtime::Trap => trap
+  puts "  Wasm trap, code: #{trap.code.inspect}"
+  puts
+end
+
+# Epoch deadline is manipulated with `Store#set_epoch_deadline`.
+store.set_epoch_deadline(1)
+puts "Running Wasm with default epoch deadline of 1..."
+puts "  result: #{instance.invoke("fibonacci", 5)}"
+puts
+
+# The engine's epoch can be incremented manually with `Engine#increment_epoch`.
+engine.increment_epoch
+puts "Running Wasm after incrementing epoch past the store's deadline..."
+begin
+  instance.invoke("fibonacci", 5)
+  raise "Unexpected: Wasm executed past deadline"
+rescue Wasmtime::Trap => trap
+  puts "  Wasm trap, code: #{trap.code.inspect}"
+  puts
+end
+
+# The engine provides a method to increment epoch based on a timer.
+# This is done with native thread because Wasm execution does not release
+# Ruby's Global VM lock.
+puts "Setting the store's deadline to be 2 ticks from current epoch..."
+store.set_epoch_deadline(2)
+
+puts "Incrementing epoch interval every 100ms..."
+engine.start_epoch_interval(100)
+start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+puts "Computing fibonacci of 100..."
+begin
+  instance.invoke("fibonacci", 100)
+  raise "Unexpected: computed fibonacci of 100 in 200ms"
+rescue Wasmtime::Trap => _
+  elapsed_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000
+  # This should be around 200ms
+  puts "  Wasm trapped after #{elapsed_ms.round}ms"
+end

--- a/examples/externref.rb
+++ b/examples/externref.rb
@@ -1,0 +1,34 @@
+require "wasmtime"
+
+engine = Wasmtime::Engine.new
+mod = Wasmtime::Module.from_file(engine, "examples/externref.wat")
+store = Wasmtime::Store.new(engine)
+instance = Wasmtime::Instance.new(store, mod)
+
+# externrefs can be any Ruby object, here we're using a String.
+hello_world = +"Hello World"
+
+puts "Set and get from table..."
+table = instance.export("table").to_table
+table.set(3, hello_world)
+puts "  get: #{table.get(3).inspect}" # => Hello World
+puts "  same Ruby object: #{table.get(3).eql?(hello_world).inspect}" # => true
+puts
+
+puts "Set and get from global..."
+global = instance.export("global").to_global
+global.set(hello_world)
+puts "  get: #{global.get.inspect}" # => "Hello World"
+puts
+
+puts "Return an externref from a function..."
+func = instance.export("func").to_func
+puts "  return: #{func.call(hello_world).inspect}" # => "Hello World"
+puts
+
+puts "nil is a valid externref..."
+puts "  nil roundtrip: #{func.call(nil).inspect}" # => nil
+puts
+
+puts "nil is also a 'null reference' externref..."
+puts "  null externref: #{table.get(6).inspect}" # => nil

--- a/examples/externref.wat
+++ b/examples/externref.wat
@@ -1,0 +1,9 @@
+(module
+  (table $table (export "table") 10 externref)
+
+  (global $global (export "global") (mut externref) (ref.null extern))
+
+  (func (export "func") (param externref) (result externref)
+    local.get 0
+  )
+)

--- a/examples/fuel.rb
+++ b/examples/fuel.rb
@@ -1,0 +1,23 @@
+require "wasmtime"
+
+config = Wasmtime::Config.new
+config.consume_fuel = true
+engine = Wasmtime::Engine.new(config)
+mod = Wasmtime::Module.from_file(engine, "examples/fuel.wat")
+
+store = Wasmtime::Store.new(engine)
+store.add_fuel(10_000)
+
+instance = Wasmtime::Instance.new(store, mod)
+
+begin
+  (1..).each do |i|
+    fuel_before = store.fuel_consumed
+    result = instance.invoke("fibonacci", i)
+    fuel_consumed = store.fuel_consumed - fuel_before
+    puts "fib(#{i}) = #{result} [consumed #{fuel_consumed} fuel]"
+  end
+rescue Wasmtime::Trap => trap
+  puts
+  puts "Wasm trap, code: #{trap.code.inspect}"
+end

--- a/examples/fuel.wat
+++ b/examples/fuel.wat
@@ -1,0 +1,13 @@
+(module
+  (func $fibonacci (param $n i32) (result i32)
+    (if
+      (i32.lt_s (local.get $n) (i32.const 2))
+      (return (local.get $n))
+    )
+    (i32.add
+      (call $fibonacci (i32.sub (local.get $n) (i32.const 1)))
+      (call $fibonacci (i32.sub (local.get $n) (i32.const 2)))
+    )
+  )
+  (export "fibonacci" (func $fibonacci))
+)

--- a/examples/linking.rb
+++ b/examples/linking.rb
@@ -1,0 +1,25 @@
+require "wasmtime"
+
+engine = Wasmtime::Engine.new
+
+# Create a linker to link modules together. We want to use WASI with
+# the linker, so we pass in `wasi: true`.
+linker = Wasmtime::Linker.new(engine, wasi: true)
+
+mod1 = Wasmtime::Module.from_file(engine, "examples/linking1.wat")
+mod2 = Wasmtime::Module.from_file(engine, "examples/linking2.wat")
+
+wasi_ctx_builder = Wasmtime::WasiCtxBuilder.new
+  .inherit_stdin
+  .inherit_stdout
+
+store = Wasmtime::Store.new(engine, wasi_ctx: wasi_ctx_builder)
+
+# Instantiate `mod2` which only uses WASI, then register
+# that instance with the linker so `mod1` can use it.
+instance2 = linker.instantiate(store, mod2)
+linker.instance(store, "linking2", instance2)
+
+# Perform the final link and execute mod1's "run" function.
+instance1 = linker.instantiate(store, mod1)
+instance1.invoke("run")

--- a/examples/linking1.wat
+++ b/examples/linking1.wat
@@ -1,0 +1,22 @@
+(module
+  (import "linking2" "double" (func $double (param i32) (result i32)))
+  (import "linking2" "log" (func $log (param i32 i32)))
+  (import "linking2" "memory" (memory 1))
+  (import "linking2" "memory_offset" (global $offset i32))
+
+  (func (export "run")
+    ;; Call into the other module to double our number, and we could print it
+    ;; here but for now we just drop it
+    i32.const 2
+    call $double
+    drop
+
+    ;; Our `data` segment initialized our imported memory, so let's print the
+    ;; string there now.
+    global.get $offset
+    i32.const 14
+    call $log
+  )
+
+  (data (global.get $offset) "Hello, world!\n")
+)

--- a/examples/linking2.wat
+++ b/examples/linking2.wat
@@ -1,0 +1,33 @@
+(module
+  (type $fd_write_ty (func (param i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_write" (func $fd_write (type $fd_write_ty)))
+
+  (func (export "double") (param i32) (result i32)
+    local.get 0
+    i32.const 2
+    i32.mul
+  )
+
+  (func (export "log") (param i32 i32)
+    ;; store the pointer in the first iovec field
+    i32.const 4
+    local.get 0
+    i32.store
+
+    ;; store the length in the first iovec field
+    i32.const 4
+    local.get 1
+    i32.store offset=4
+
+    ;; call the `fd_write` import
+    i32.const 1     ;; stdout fd
+    i32.const 4     ;; iovs start
+    i32.const 1     ;; number of iovs
+    i32.const 0     ;; where to write nwritten bytes
+    call $fd_write
+    drop
+  )
+
+  (memory (export "memory") 2)
+  (global (export "memory_offset") i32 (i32.const 65536))
+)

--- a/examples/memory.rb
+++ b/examples/memory.rb
@@ -1,0 +1,49 @@
+require "wasmtime"
+
+engine = Wasmtime::Engine.new
+mod = Wasmtime::Module.from_file(engine, "examples/memory.wat")
+store = Wasmtime::Store.new(engine)
+instance = Wasmtime::Instance.new(store, mod)
+memory = instance.export("memory").to_memory
+size_fn = instance.export("size").to_func
+load_fn = instance.export("load").to_func
+store_fn = instance.export("store").to_func
+
+puts "Checking memory..."
+puts "  size: #{memory.size}" # => 2
+puts "  read(0, 1): #{memory.read(0, 1).inspect}" # => "\x00"
+puts
+puts "  size_fn.call: #{size_fn.call}" # => 2
+puts "  load_fn.call(0): #{load_fn.call(0)}" # => 0
+puts
+
+puts "Reading out of bounds..."
+begin
+  load_fn.call(0x20000)
+rescue Wasmtime::Trap => error
+  puts "  Trap! code: #{error.code.inspect}"
+end
+puts
+
+puts "Mutating memory..."
+memory.write(0x1002, "\x06")
+puts "  load_fn.call(0x1002): #{load_fn.call(0x1002).inspect}" # => 6
+store_fn.call(0x1003, 7)
+puts "  load_fn.call(0x1003): #{load_fn.call(0x1003).inspect}" # => 7
+puts
+
+puts "Growing memory..."
+memory.grow(1)
+puts "  new size: #{memory.size}" # => 3
+puts
+
+puts "Creating stand-alone memory..."
+memory = Wasmtime::Memory.new(store, min_size: 5, max_size: 5) # size in pages
+puts "  size: #{memory.size}" # => 5
+puts
+puts "Growing beyond limit fails..."
+begin
+  memory.grow(1)
+rescue Wasmtime::Error => error
+  puts "  exception: #{error.inspect}"
+end

--- a/examples/memory.wat
+++ b/examples/memory.wat
@@ -1,0 +1,13 @@
+(module
+  (memory (export "memory") 2 3)
+
+  (func (export "size") (result i32) (memory.size))
+  (func (export "load") (param i32) (result i32)
+    (i32.load8_s (local.get 0))
+  )
+  (func (export "store") (param i32 i32)
+    (i32.store8 (local.get 0) (local.get 1))
+  )
+
+  (data (i32.const 0x1000) "\01\02\03\04")
+)

--- a/examples/multi.rb
+++ b/examples/multi.rb
@@ -1,0 +1,26 @@
+require "wasmtime"
+
+engine = Wasmtime::Engine.new
+mod = Wasmtime::Module.from_file(engine, "examples/multi.wat")
+store = Wasmtime::Store.new(engine)
+
+# Host call with multiple params and results
+callback = Wasmtime::Func.new(store, [:i32, :i64], [:i64, :i32]) do |_caller, a, b|
+  # Return an array with 2 elements for 2 results
+  [b + 1, a + 1]
+end
+
+instance = Wasmtime::Instance.new(store, mod, [callback])
+
+g = instance.export("g").to_func
+
+puts "Calling export 'g'..."
+result = g.call(1, 3) # => [2, 4]
+puts "  g result: #{result.inspect}"
+puts
+
+round_trip_many = instance.export("round_trip_many").to_func
+
+puts "Calling export 'round_trip_many'..."
+result = round_trip_many.call(0, 1, 2, 3, 4, 5, 6, 7, 8, 9) # => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+puts "  round_trip_many result: #{result.inspect}"

--- a/examples/multi.wat
+++ b/examples/multi.wat
@@ -1,0 +1,23 @@
+(module
+  (func $f (import "" "f") (param i32 i64) (result i64 i32))
+
+  (func $g (export "g") (param i32 i64) (result i64 i32)
+    (call $f (local.get 0) (local.get 1))
+  )
+
+  (func $round_trip_many
+    (export "round_trip_many")
+    (param i64 i64 i64 i64 i64 i64 i64 i64 i64 i64)
+    (result i64 i64 i64 i64 i64 i64 i64 i64 i64 i64)
+
+    local.get 0
+    local.get 1
+    local.get 2
+    local.get 3
+    local.get 4
+    local.get 5
+    local.get 6
+    local.get 7
+    local.get 8
+    local.get 9)
+)


### PR DESCRIPTION
Add a bunch of examples, essentially copying the wasmtime's examples directory and adapting to Ruby.


I wanted the examples to be dead simple to copy paste. They should have no external dependency (no external helper, no gem, nothing). This means we don't do `assert` (there's no built-in assert in Ruby) and no helper functions.