### PR TITLE
Improve error handling

### DIFF
--- a/ext/src/ruby_api/caller.rs
+++ b/ext/src/ruby_api/caller.rs
@@ -1,8 +1,8 @@
 use super::{convert::WrapWasmtimeType, externals::Extern, root, store::StoreData};
 use crate::{error, helpers::WrappedStruct};
 use magnus::{
-    memoize, method, r_typed_data::DataTypeBuilder, DataTypeFunctions, Error, Exception,
-    Module as _, RClass, RString, TypedData, Value, QNIL,
+    memoize, method, r_typed_data::DataTypeBuilder, DataTypeFunctions, Error, Module as _, RClass,
+    RString, TypedData, Value, QNIL,
 };
 use std::cell::UnsafeCell;
 use wasmtime::{AsContext, AsContextMut, Caller as CallerImpl, StoreContext, StoreContextMut};
@@ -117,14 +117,6 @@ impl<'a> Caller<'a> {
 
     pub fn expire(&self) {
         self.handle.expire();
-    }
-
-    pub fn hold_exception(&self, exception: Exception) {
-        self.context_mut()
-            .unwrap()
-            .data_mut()
-            .exception()
-            .hold(exception);
     }
 }
 

--- a/ext/src/ruby_api/errors.rs
+++ b/ext/src/ruby_api/errors.rs
@@ -15,6 +15,11 @@ pub fn not_implemented_error() -> ExceptionClass {
     })
 }
 
+/// The `Wasmtime::ResultError` class.
+pub fn result_error() -> ExceptionClass {
+    *memoize!(ExceptionClass: root().define_error("ResultError", base_error()).unwrap())
+}
+
 /// The `Wasmtime::ConversionError` class.
 pub fn conversion_error() -> ExceptionClass {
     *memoize!(ExceptionClass: root().define_error("ConversionError", base_error()).unwrap())
@@ -55,6 +60,7 @@ macro_rules! conversion_err {
 
 pub fn init() -> Result<(), Error> {
     let _ = base_error();
+    let _ = result_error();
     let _ = conversion_error();
     let _ = wasi_exit_error();
 

--- a/ext/src/ruby_api/func.rs
+++ b/ext/src/ruby_api/func.rs
@@ -228,12 +228,6 @@ pub fn make_func_closure(
 
         let result = callable
             .call(unsafe { rparams.as_slice() })
-            .map_err(|e| {
-                if let Error::Exception(exception) = e {
-                    caller.hold_exception(exception);
-                }
-                e
-            })
             .and_then(|proc_result| {
                 match results.len() {
                     0 => Ok(()), // Ignore return value
@@ -258,13 +252,7 @@ pub fn make_func_closure(
                     }
                 }
             })
-            .map_err(|e| {
-                anyhow::anyhow!(format!(
-                    "Error when calling Func {}\n Error: {}",
-                    callable.inspect(),
-                    e
-                ))
-            });
+            .map_err(|e| anyhow::anyhow!(e));
 
         // Drop the wasmtime::Caller so it does not outlive the Func call, if e.g. the user
         // assigned the Ruby Wasmtime::Caller instance to a global.

--- a/ext/src/ruby_api/func.rs
+++ b/ext/src/ruby_api/func.rs
@@ -1,10 +1,11 @@
 use super::{
     convert::{ToRubyValue, ToSym, ToValTypeVec, ToWasmVal},
+    errors::result_error,
     params::Params,
     root,
     store::{Store, StoreContextValue, StoreData},
 };
-use crate::{error, helpers::WrappedStruct, Caller};
+use crate::{helpers::WrappedStruct, Caller};
 use magnus::{
     block::Proc, function, memoize, method, r_typed_data::DataTypeBuilder, scan_args::scan_args,
     value::BoxValue, DataTypeFunctions, Error, Exception, Module as _, Object, RArray, RClass,
@@ -235,18 +236,28 @@ pub fn make_func_closure(
                         // For len=1, accept both `val` and `[val]`
                         let proc_result = RArray::try_convert(proc_result)?;
                         if proc_result.len() != n {
-                            return Result::Err(error!(
-                                "wrong number of results (given {}, expected {})",
-                                proc_result.len(),
-                                n
+                            return Err(Error::new(
+                                result_error(),
+                                format!(
+                                    "wrong number of results (given {}, expected {}) in {}",
+                                    proc_result.len(),
+                                    n,
+                                    callable,
+                                ),
                             ));
                         }
-                        for ((rb_val, wasm_val), ty) in unsafe { proc_result.as_slice() }
+                        for (i, ((rb_val, wasm_val), ty)) in unsafe { proc_result.as_slice() }
                             .iter()
                             .zip(results.iter_mut())
                             .zip(ty.results())
+                            .enumerate()
                         {
-                            *wasm_val = rb_val.to_wasm_val(&ty)?;
+                            *wasm_val = rb_val.to_wasm_val(&ty).map_err(|e| {
+                                Error::new(
+                                    result_error(),
+                                    format!("{} (result index {} in {})", e, i, callable),
+                                )
+                            })?;
                         }
                         Ok(())
                     }

--- a/ext/src/ruby_api/trap.rs
+++ b/ext/src/ruby_api/trap.rs
@@ -59,6 +59,8 @@ impl Trap {
     /// @return [Symbol, nil]
     pub fn code(&self) -> Result<Option<Symbol>, Error> {
         match self.trap {
+            wasmtime::Trap::StackOverflow => trap_const!(STACK_OVERFLOW),
+            wasmtime::Trap::MemoryOutOfBounds => trap_const!(MEMORY_OUT_OF_BOUNDS),
             wasmtime::Trap::HeapMisaligned => trap_const!(HEAP_MISALIGNED),
             wasmtime::Trap::TableOutOfBounds => trap_const!(TABLE_OUT_OF_BOUNDS),
             wasmtime::Trap::IndirectCallToNull => trap_const!(INDIRECT_CALL_TO_NULL),

--- a/lib/wasmtime.rb
+++ b/lib/wasmtime.rb
@@ -17,6 +17,7 @@ module Wasmtime
 
   class Trap < Error
     STACK_OVERFLOW = :stack_overflow
+    MEMORY_OUT_OF_BOUNDS = :memory_out_of_bounds
     HEAP_MISALIGNED = :heap_misaligned
     TABLE_OUT_OF_BOUNDS = :table_out_of_bounds
     INDIRECT_CALL_TO_NULL = :indirect_call_to_null

--- a/lib/wasmtime.rb
+++ b/lib/wasmtime.rb
@@ -13,8 +13,14 @@ end
 module Wasmtime
   class Error < StandardError; end
 
+  # Raised when failing to convert the return value of a Ruby-backed Func to
+  # Wasm types.
+  class ResultError < Error; end
+
+  # Raised when converting an {Extern} to its concrete type fails.
   class ConversionError < Error; end
 
+  # Raised on Wasm trap.
   class Trap < Error
     STACK_OVERFLOW = :stack_overflow
     MEMORY_OUT_OF_BOUNDS = :memory_out_of_bounds


### PR DESCRIPTION
* Refactor: remove the need to hold host exception on the store, downcast the exception instead.
* Add missing trap codes for Wasm traps.
* Improve experience of param and result 
  * Introduce a new `ResultError` for when a host call's result can't be converted. The exception message contains `Proc#inspect` -- it's verbose but I suspect this will help a lot when debugging.
  * Change `Wasmtime::Error` to `ArgumentError` when calling a Wasm function with incorrect arity.
  * Specify which param or result failed to convert by adding its index to the error message.