### PR TITLE
Speed up func calls

### DIFF
--- a/bench/func_call.rb
+++ b/bench/func_call.rb
@@ -4,15 +4,16 @@ Bench.ips do |x|
   engine = Wasmtime::Engine.new
   linker = Wasmtime::Linker.new(engine)
   mod = Wasmtime::Module.from_file(engine, "examples/gcd.wat")
+  store = Wasmtime::Store.new(engine)
+  instance = linker.instantiate(store, mod)
+  func = instance.export("gcd").to_func
 
   x.report("Instance#invoke") do
-    store = Wasmtime::Store.new(engine)
-    linker.instantiate(store, mod).invoke("gcd", 5, 1)
+    instance.invoke("gcd", 5, 1)
   end
 
   x.report("Func#call") do
-    store = Wasmtime::Store.new(engine)
-    linker.instantiate(store, mod).export("gcd").to_func.call(5, 1)
+    func.call(5, 1)
   end
 
   x.compare!

--- a/ext/src/ruby_api/func.rs
+++ b/ext/src/ruby_api/func.rs
@@ -174,12 +174,12 @@ impl<'a> Func<'a> {
         func: &wasmtime::Func,
         args: &[Value],
     ) -> Result<Value, Error> {
-        let func_ty = func.ty(store.context_mut()?);
-        let param_types = func_ty.params().collect::<Vec<_>>();
-        let params = Params::new(args, param_types)?.to_vec()?;
+        let mut context = store.context_mut()?;
+        let func_ty = func.ty(&mut context);
+        let params = Params::new(&func_ty, args)?.to_vec()?;
         let mut results = vec![Val::null(); func_ty.results().len()];
 
-        func.call(store.context_mut()?, &params, &mut results)
+        func.call(context, &params, &mut results)
             .map_err(|e| store.handle_wasm_error(e))?;
 
         match results.as_slice() {


### PR DESCRIPTION
- Fetch the store context only once
- Get rid of Vec allocation for param types, instead use the FuncType.

Before:
```
Calculating -------------------------------------
     Instance#invoke      2.188M (± 0.8%) i/s -     10.941M in   5.001141s
           Func#call      2.597M (± 0.7%) i/s -     13.178M in   5.075365s
```

After:
```
Calculating -------------------------------------
     Instance#invoke      2.527M (± 0.5%) i/s -     12.712M in   5.030878s
           Func#call      3.071M (± 1.0%) i/s -     15.484M in   5.042146s
```


This is a modest gain (~15%), but I see no downside so why not. I have a [branch that speeds up by another ~17%](https://github.com/bytecodealliance/wasmtime-rb/compare/speedup-func-call-unsafe) but that required using unsafe, so I'll sit on it for now.

Wasm func call is still much slower than a regular `Proc#call` (by almost 2 order of magnitudes IIRC), but it's probably acceptable still. We're talking ~0.33us for `Func#call` if I'm doing my math right.