### PR TITLE
Bump rb-sys to 0.9.54 for Ruby 3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,18 +1070,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.53"
+version = "0.9.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa291f69bcc44f8e96597a3f39e9933fde6977b825415cfaa670ac49b8ab7c99"
+checksum = "b3277448b8eee18de8bedb18883ae02dcd60d47922ddfc6ab408def77da0a9b4"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.53"
+version = "0.9.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d998fd6ef588471d6d7cca24c4da88eda5e6757b6885c55760e856ecdb254c3d"
+checksum = "c9baae802c93180af02cccb21819589d109070f8e28e14e7070a9ffdeca9b464"
 dependencies = [
  "bindgen",
  "regex",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,6 @@ GEM
     benchmark-ips (2.10.0)
     diff-lcs (1.5.0)
     ffi (1.15.5)
-    ffi (1.15.5-x64-mingw-ucrt)
-    ffi (1.15.5-x64-mingw32)
     get_process_mem (0.2.7)
       ffi (~> 1.0)
     json (2.6.3)
@@ -25,7 +23,7 @@ GEM
     rake (13.0.6)
     rake-compiler (1.2.1)
       rake
-    rb_sys (0.9.53)
+    rb_sys (0.9.54)
     regexp_parser (2.6.1)
     rexml (3.2.5)
     rspec (3.12.0)


### PR DESCRIPTION
Now supports precompiling gems for 3.2. I manually ran the [build gem workflow](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/3867643880) and indeed there's a precompiled gem for 3.2 workflow's artifact:

```
$ gem unpack wasmtime-0.4.1-arm64-darwin.gem
$ find wasmtime-0.4.1-arm64-darwin -type f | grep 3.2
wasmtime-0.4.1-arm64-darwin/lib/wasmtime/3.2/wasmtime_rb.bundle
```

