### PR TITLE
Version oxidize-rb actions

### DIFF
--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -17,7 +17,7 @@ jobs:
       result: ${{ steps.fetch.outputs.result }}
     steps:
       - id: fetch
-        uses: oxidize-rb/actions/fetch-ci-data@main
+        uses: oxidize-rb/actions/fetch-ci-data@v1
         with:
           supported-ruby-platforms: |
             exclude: [arm-linux] # no cranelift support yet
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: oxidize-rb/actions/setup-ruby-and-rust@main
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
           ruby-version: "3.1"
           bundler-cache: false
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: oxidize-rb/actions/setup-ruby-and-rust@main
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       result: ${{ steps.fetch.outputs.result }}
     steps:
       - id: fetch
-        uses: oxidize-rb/actions/fetch-ci-data@main
+        uses: oxidize-rb/actions/fetch-ci-data@v1
 
   ci:
     runs-on: ${{ matrix.os }}
@@ -36,7 +36,7 @@ jobs:
       - name: Remove Gemfile.lock
         run: rm Gemfile.lock
 
-      - uses: oxidize-rb/actions/setup-ruby-and-rust@main
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -5,15 +5,15 @@ on:
   workflow_dispatch:
     inputs:
       ruby-version:
-        description: 'Ruby version to memcheck'
+        description: "Ruby version to memcheck"
         required: true
-        default: '3.1'
+        default: "3.1"
         type: choice
         options:
-          - 'head'
-          - '3.1'
-          - '3.0'
-          - '2.7'
+          - "head"
+          - "3.1"
+          - "3.0"
+          - "2.7"
   push:
 
 concurrency:
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: oxidize-rb/actions/setup-ruby-and-rust@main
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
           ruby-version: ${{ inputs.ruby-version || '3.1' }}
           bundler-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       result: ${{ steps.fetch.outputs.result }}
     steps:
       - id: fetch
-        uses: oxidize-rb/actions/fetch-ci-data@main
+        uses: oxidize-rb/actions/fetch-ci-data@v1
         with:
           supported-ruby-platforms: |
             exclude: [arm-linux] # no cranelift support yet
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: oxidize-rb/actions/setup-ruby-and-rust@main
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
           ruby-version: "3.1"
           bundler-cache: false
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: oxidize-rb/actions/setup-ruby-and-rust@main
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
           ruby-version: "3.1"
           bundler-cache: true


### PR DESCRIPTION
This PR uses the new semver tags for the [`ozidize-rb/actions`](https://github.com/oxidize-rb/actions).