### PR TITLE
Add `Memory#slice` for zero-copy data access

### DIFF
--- a/ext/src/ruby_api/memory.rs
+++ b/ext/src/ruby_api/memory.rs
@@ -128,7 +128,7 @@ impl<'a> Memory<'a> {
     }
 
     /// @yard
-    /// Read +size+ bytes starting at +offset+ into a `[Wasmtime::Memory::Slice`. This
+    /// Read +size+ bytes starting at +offset+ into a {Slice}. This
     /// provides a way to read a slice of memory without copying the data.
     ///
     /// Resizing the memory (as with `Wasmtime::Memory#grow`) will invalidate

--- a/ext/src/ruby_api/memory.rs
+++ b/ext/src/ruby_api/memory.rs
@@ -129,7 +129,10 @@ impl<'a> Memory<'a> {
 
     /// @yard
     /// Read +size+ bytes starting at +offset+ into a `[Wasmtime::Memory::Slice`. This
-    /// proivdes a way to read a slice of memory without copying the data.
+    /// provides a way to read a slice of memory without copying the data.
+    ///
+    /// Resizing the memory (as with `Wasmtime::Memory#grow`) will invalidate
+    /// the slice, causing any attempt to read the slice to raise an error.
     ///
     /// @def slice(offset, size)
     /// @param offset [Integer]

--- a/ext/src/ruby_api/memory.rs
+++ b/ext/src/ruby_api/memory.rs
@@ -128,23 +128,23 @@ impl<'a> Memory<'a> {
     }
 
     /// @yard
-    /// Read +size+ bytes starting at +offset+ into a {Slice}. This
+    /// Read +size+ bytes starting at +offset+ into an {UnsafeSlice}. This
     /// provides a way to read a slice of memory without copying the underlying
     /// data.
     ///
-    /// The returned {Slice} lazily reads the underlying memory, meaning that
+    /// The returned {UnsafeSlice} lazily reads the underlying memory, meaning that
     /// the actual pointer to the string buffer is not materialzed until
-    /// `Slice#to_str` or {Slice#to_memory_view} is called.
+    /// {UnsafeSlice#to_str} or {UnsafeSlice#to_memory_view} is called.
     ///
-    /// SAFETY: Resizing the memory (as with `Wasmtime::Memory#grow`) will
-    /// invalidate the {Slice}, and future attempts to read the slice wil raise
-    /// an error.  However, it is not possible to invalidate the Ruby {String}
-    /// object after calling `Slice#to_str`. As such, the caller must ensure
+    /// SAFETY: Resizing the memory (as with {Wasmtime::Memory#grow}) will
+    /// invalidate the {UnsafeSlice}, and future attempts to read the slice will raise
+    /// an error.  However, it is not possible to invalidate the Ruby +String+
+    /// object after calling {Memory::UnsafeSlice#to_str}. As such, the caller must ensure
     /// that the Wasmtime {Memory} is not resized while holding the Ruby string.
-    /// Failing to do so could result in the {String} buffer pointing to invalid
+    /// Failing to do so could result in the +String+ buffer pointing to invalid
     /// memory.
     ///
-    /// In general, you should prefer using `Memory#read` or `Memory#read_utf8`
+    /// In general, you should prefer using {Memory#read} or {Memory#read_utf8}
     /// over this method unless you know what you're doing.
     ///
     /// @def read_unsafe_slice(offset, size)

--- a/ext/src/ruby_api/memory.rs
+++ b/ext/src/ruby_api/memory.rs
@@ -129,23 +129,23 @@ impl<'a> Memory<'a> {
 
     /// @yard
     /// Read +size+ bytes starting at +offset+ into a {Slice}. This
-    /// provides a way to read a slice of memory without copying the data.
+    /// provides a way to read a slice of memory without copying the underlying
+    /// data.
     ///
     /// The returned {Slice} lazily reads the underlying memory, meaning that
     /// the actual pointer to the string buffer is not materialzed until
-    /// `Slice#to_str` is called.
+    /// `Slice#to_str` or {Slice#to_memory_view} is called.
     ///
-    /// SAFETY: Resizing the memory (as with `Wasmtime::Memory#grow`) will invalidate
-    /// the slice, causing any attempt to read the slice to raise an error.
-    /// However, it is not possible to invalidate the Ruby {String} object after
-    /// calling `Slice#to_str`.
-    ///
-    /// As such, the caller must ensure that the Wasmtime {Memory} is not
-    /// resized will the while holding the Ruby string.  Failing to do so could
-    /// result in reading invalid memory.
+    /// SAFETY: Resizing the memory (as with `Wasmtime::Memory#grow`) will
+    /// invalidate the {Slice}, and future attempts to read the slice wil raise
+    /// an error.  However, it is not possible to invalidate the Ruby {String}
+    /// object after calling `Slice#to_str`. As such, the caller must ensure
+    /// that the Wasmtime {Memory} is not resized while holding the Ruby string.
+    /// Failing to do so could result in the {String} buffer pointing to invalid
+    /// memory.
     ///
     /// In general, you should prefer using `Memory#read` or `Memory#read_utf8`
-    /// over this method, unless you know what you're doing.
+    /// over this method unless you know what you're doing.
     ///
     /// @def read_unsafe_slice(offset, size)
     /// @param offset [Integer]

--- a/ext/src/ruby_api/memory/slice.rs
+++ b/ext/src/ruby_api/memory/slice.rs
@@ -1,0 +1,184 @@
+use crate::{define_data_class, define_rb_intern, error, helpers::WrappedStruct, Memory};
+use magnus::{
+    class::object,
+    gc, memoize, method,
+    r_typed_data::DataTypeBuilder,
+    rb_sys::{AsRawId, AsRawValue, FromRawValue},
+    require,
+    value::Id,
+    DataTypeFunctions, Error, Module as _, RClass, RModule, TypedData, Value,
+};
+use rb_sys::{
+    rb_ivar_set, rb_memory_view_entry, rb_memory_view_init_as_byte_array, rb_memory_view_register,
+    rb_memory_view_t, rb_obj_freeze, rb_str_new_static, VALUE,
+};
+use std::ops::Range;
+
+/// @yard
+/// @rename Wasmtime::Memory::Slice
+/// Represents a slice of a WebAssembly memory. This is useful for creating Ruby
+/// strings from WASM memory without any extra memory allocations.
+#[derive(Debug)]
+pub struct Slice<'a> {
+    memory: MemoryGuard<'a>,
+    range: Range<usize>,
+}
+
+define_rb_intern!(IVAR_NAME => "@__slice__",);
+
+unsafe impl TypedData for Slice<'_> {
+    fn class() -> magnus::RClass {
+        *memoize!(RClass: define_data_class!(Memory::class(), "Slice"))
+    }
+
+    fn data_type() -> &'static magnus::DataType {
+        memoize!(magnus::DataType: {
+            let mut builder = DataTypeBuilder::<Slice>::new("Wasmtime::Memory::Slice");
+            builder.free_immediately();
+            builder.mark();
+            builder.build()
+        })
+    }
+}
+
+impl DataTypeFunctions for Slice<'_> {
+    fn mark(&self) {
+        self.memory.mark()
+    }
+}
+
+fn fiddle_memory_view_class() -> Option<RClass> {
+    let fiddle = object().const_get::<_, RModule>("Fiddle").ok()?;
+    fiddle.const_get("MemoryView").ok()
+}
+
+impl<'a> Slice<'a> {
+    pub fn new(memory: WrappedStruct<Memory<'a>>, range: Range<usize>) -> Result<Self, Error> {
+        let memory = MemoryGuard::new(memory)?;
+        let slice = Self { memory, range };
+        let _ = slice.get_raw_slice()?; // Check that the slice is valid.
+        Ok(slice)
+    }
+
+    /// @yard
+    /// Get this slice as a Fiddle memory view, which can be cheaply read by
+    /// other Ruby extensions.
+    ///
+    /// @def to_memory_view
+    /// @return [Fiddle::MemoryView] Memory view of the slice.
+    pub fn to_memory_view(rb_self: WrappedStruct<Self>) -> Result<Value, Error> {
+        let klass = *memoize!(RClass: {
+            let c = fiddle_memory_view_class().unwrap();
+            gc::register_mark_object(c);
+            c
+        });
+
+        klass.new_instance((rb_self,))
+    }
+
+    /// @yard
+    /// Gets the memory slice as a Ruby string without copying the underlying buffer.
+    ///
+    /// @def to_s
+    /// @return [String] Binary +String+ of the memory.
+    pub fn to_s(rb_self: WrappedStruct<Self>) -> Result<Value, Error> {
+        let raw_slice = rb_self.get()?.get_raw_slice()?;
+        let id: Id = (*IVAR_NAME).into();
+        let rstring = unsafe {
+            let val = rb_str_new_static(raw_slice.as_ptr() as _, raw_slice.len() as _);
+            rb_ivar_set(val, id.as_raw(), rb_self.as_raw());
+            rb_obj_freeze(val)
+        };
+
+        Ok(unsafe { Value::from_raw(rstring) })
+    }
+
+    fn get_raw_slice(&self) -> Result<&[u8], Error> {
+        let mem = self.memory.get()?;
+
+        mem.data()?
+            .get(self.range.clone())
+            .ok_or_else(|| error!("out of bounds memory access"))
+    }
+
+    fn register_memory_view() -> Result<(), Error> {
+        let class = Self::class();
+
+        static ENTRY: rb_memory_view_entry = rb_memory_view_entry {
+            get_func: Some(Slice::initialize_memory_view),
+            release_func: None,
+            available_p_func: Some(Slice::is_memory_view_available),
+        };
+
+        if unsafe { rb_memory_view_register(class.as_raw(), &ENTRY) } {
+            Ok(())
+        } else {
+            Err(error!("failed to register memory view"))
+        }
+    }
+
+    extern "C" fn initialize_memory_view(
+        value: VALUE,
+        view: *mut rb_memory_view_t,
+        _flags: i32,
+    ) -> bool {
+        let obj = unsafe { Value::from_raw(value) };
+        let Ok(memory) = obj.try_convert::<WrappedStruct<Slice>>() else { return false };
+        let Ok(memory) = memory.get() else { return false; };
+        let Ok(raw_slice) = memory.get_raw_slice() else { return false; };
+        let (ptr, size) = (raw_slice.as_ptr(), raw_slice.len());
+
+        unsafe { rb_memory_view_init_as_byte_array(view, value, ptr as _, size as _, true) }
+    }
+
+    extern "C" fn is_memory_view_available(value: VALUE) -> bool {
+        let obj = unsafe { Value::from_raw(value) };
+        let Ok(memory) = obj.try_convert::<WrappedStruct<Slice>>() else { return false };
+        let Ok(memory) = memory.get() else { return false; };
+
+        memory.get_raw_slice().is_ok()
+    }
+}
+
+/// A guard that ensures that a memory slice is not invalidated by resizing
+#[derive(Debug)]
+pub struct MemoryGuard<'a> {
+    memory: WrappedStruct<Memory<'a>>,
+    original_size: u64,
+}
+
+impl<'a> MemoryGuard<'a> {
+    pub fn new(memory: WrappedStruct<Memory<'a>>) -> Result<Self, Error> {
+        let original_size = memory.get()?.size()?;
+
+        Ok(Self {
+            memory,
+            original_size,
+        })
+    }
+
+    pub fn get(&self) -> Result<&Memory<'a>, Error> {
+        let mem = self.memory.get()?;
+
+        if mem.size()? != self.original_size {
+            Err(error!("memory slice was invalidated by resize"))
+        } else {
+            Ok(mem)
+        }
+    }
+
+    pub fn mark(&self) {
+        self.memory.mark()
+    }
+}
+
+pub fn init() -> Result<(), Error> {
+    Slice::class().define_method("to_s", method!(Slice::to_s, 0))?;
+
+    if require("fiddle").is_ok() && fiddle_memory_view_class().is_some() {
+        Slice::register_memory_view()?;
+        Slice::class().define_method("to_memory_view", method!(Slice::to_memory_view, 0))?;
+    }
+
+    Ok(())
+}

--- a/ext/src/ruby_api/memory/slice.rs
+++ b/ext/src/ruby_api/memory/slice.rs
@@ -9,8 +9,8 @@ use magnus::{
     DataTypeFunctions, Error, Module as _, RClass, RModule, TypedData, Value,
 };
 use rb_sys::{
-    rb_ivar_set, rb_memory_view_entry, rb_memory_view_init_as_byte_array, rb_memory_view_register,
-    rb_memory_view_t, rb_obj_freeze, rb_str_new_static, VALUE,
+    rb_ivar_set, rb_memory_view_entry_t, rb_memory_view_init_as_byte_array,
+    rb_memory_view_register, rb_memory_view_t, rb_obj_freeze, rb_str_new_static, VALUE,
 };
 use std::ops::Range;
 
@@ -104,7 +104,7 @@ impl<'a> Slice<'a> {
     fn register_memory_view() -> Result<(), Error> {
         let class = Self::class();
 
-        static ENTRY: rb_memory_view_entry = rb_memory_view_entry {
+        static ENTRY: rb_memory_view_entry_t = rb_memory_view_entry_t {
             get_func: Some(Slice::initialize_memory_view),
             release_func: None,
             available_p_func: Some(Slice::is_memory_view_available),

--- a/ext/src/ruby_api/memory/slice.rs
+++ b/ext/src/ruby_api/memory/slice.rs
@@ -79,9 +79,9 @@ impl<'a> Slice<'a> {
     /// @yard
     /// Gets the memory slice as a Ruby string without copying the underlying buffer.
     ///
-    /// @def to_s
+    /// @def to_str
     /// @return [String] Binary +String+ of the memory.
-    pub fn to_s(rb_self: WrappedStruct<Self>) -> Result<Value, Error> {
+    pub fn to_str(rb_self: WrappedStruct<Self>) -> Result<Value, Error> {
         let raw_slice = rb_self.get()?.get_raw_slice()?;
         let id: Id = (*IVAR_NAME).into();
         let rstring = unsafe {
@@ -173,7 +173,7 @@ impl<'a> MemoryGuard<'a> {
 }
 
 pub fn init() -> Result<(), Error> {
-    Slice::class().define_method("to_s", method!(Slice::to_s, 0))?;
+    Slice::class().define_method("to_str", method!(Slice::to_str, 0))?;
 
     if require("fiddle").is_ok() && fiddle_memory_view_class().is_some() {
         Slice::register_memory_view()?;

--- a/ext/src/ruby_api/memory/slice.rs
+++ b/ext/src/ruby_api/memory/slice.rs
@@ -180,6 +180,7 @@ impl<'a> MemoryGuard<'a> {
 }
 
 pub fn init() -> Result<(), Error> {
+    Slice::class().define_method("to_s", method!(Slice::to_str, 0))?;
     Slice::class().define_method("to_str", method!(Slice::to_str, 0))?;
 
     #[cfg(ruby_gte_3_0)]

--- a/ext/src/ruby_api/memory/unsafe_slice.rs
+++ b/ext/src/ruby_api/memory/unsafe_slice.rs
@@ -21,9 +21,9 @@ use std::ops::Range;
 /// Represents a slice of a WebAssembly memory. This is useful for creating Ruby
 /// strings from WASM memory without any extra memory allocations.
 ///
-/// The returned {Slice} lazily reads the underlying memory, meaning that
+/// The returned {UnsafeSlice} lazily reads the underlying memory, meaning that
 /// the actual pointer to the string buffer is not materialzed until
-/// `Slice#to_str` is called.k
+/// {UnsafeSlice#to_str} is called.
 #[derive(Debug)]
 pub struct UnsafeSlice<'a> {
     memory: MemoryGuard<'a>,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require "wasmtime"
 
 RSpec.shared_context("default lets") do
   let(:engine) { Wasmtime::Engine.new }
-  let(:store_data) { {} }
+  let(:store_data) { Object.new }
   let(:store) { Wasmtime::Store.new(engine, store_data) }
   let(:wat) { "(module)" }
 

--- a/spec/unit/func_spec.rb
+++ b/spec/unit/func_spec.rb
@@ -149,7 +149,7 @@ module Wasmtime
     private
 
     def build_func(params, results, &block)
-      store = Store.new(engine, {})
+      store = Store.new(engine, Object.new)
       Func.new(store, params, results, &block)
     end
   end

--- a/spec/unit/memory_spec.rb
+++ b/spec/unit/memory_spec.rb
@@ -88,11 +88,11 @@ module Wasmtime
       end
     end
 
-    describe "#slice" do
+    describe "#unsafe_slice" do
       it "exposes a frozen string" do
         mem = Memory.new(store, min_size: 1)
         mem.write(0, "foo")
-        str = String(mem.slice(0, 3))
+        str = String(mem.read_unsafe_slice(0, 3))
 
         expect(str).to eq("foo")
         expect(str.encoding).to eq(Encoding::ASCII_8BIT)
@@ -103,7 +103,7 @@ module Wasmtime
         it "exposes a memory view" do
           mem = Memory.new(store, min_size: 3)
           mem.write(0, "foo")
-          view = mem.slice(0, 3).to_memory_view
+          view = mem.read_unsafe_slice(0, 3).to_memory_view
 
           expect(view).to be_a(Fiddle::MemoryView)
           expect(view).to be_readonly
@@ -115,7 +115,7 @@ module Wasmtime
       it "invalidates the size when the memory is resized" do
         mem = Memory.new(store, min_size: 1)
         mem.write(0, "foo")
-        slice = mem.slice(0, 3)
+        slice = mem.read_unsafe_slice(0, 3)
         mem.grow(1)
 
         expect { slice.to_str }
@@ -130,7 +130,7 @@ module Wasmtime
       it "errors when the memory is out of bounds" do
         mem = Memory.new(store, min_size: 1)
 
-        expect { mem.slice(64 * 2**10, 1) }
+        expect { mem.read_unsafe_slice(64 * 2**10, 1) }
           .to raise_error(Wasmtime::Error, "out of bounds memory access")
       end
     end

--- a/spec/unit/memory_spec.rb
+++ b/spec/unit/memory_spec.rb
@@ -90,7 +90,7 @@ module Wasmtime
 
     describe "#slice" do
       it "exposes a frozen string" do
-        mem = Memory.new(store, min_size: 3)
+        mem = Memory.new(store, min_size: 1)
         mem.write(0, "foo")
         str = String(mem.slice(0, 3))
 

--- a/spec/unit/memory_spec.rb
+++ b/spec/unit/memory_spec.rb
@@ -99,15 +99,17 @@ module Wasmtime
         expect(str).to be_frozen
       end
 
-      it "exposes a memory view" do
-        mem = Memory.new(store, min_size: 3)
-        mem.write(0, "foo")
-        view = mem.slice(0, 3).to_memory_view
+      if RUBY_VERSION >= "3.0.0"
+        it "exposes a memory view" do
+          mem = Memory.new(store, min_size: 3)
+          mem.write(0, "foo")
+          view = mem.slice(0, 3).to_memory_view
 
-        expect(view).to be_a(Fiddle::MemoryView)
-        expect(view).to be_readonly
-        expect(view.ndim).to eq(1)
-        expect(view.to_s).to eq("foo")
+          expect(view).to be_a(Fiddle::MemoryView)
+          expect(view).to be_readonly
+          expect(view.ndim).to eq(1)
+          expect(view.to_s).to eq("foo")
+        end
       end
 
       it "invalidates the size when the memory is resized" do
@@ -118,8 +120,11 @@ module Wasmtime
 
         expect { slice.to_str }
           .to raise_error(Wasmtime::Error, "memory slice was invalidated by resize")
-        expect { slice.to_memory_view }
-          .to raise_error(ArgumentError, /Unable to get a memory view from/)
+
+        if RUBY_VERSION >= "3.0.0"
+          expect { slice.to_memory_view }
+            .to raise_error(ArgumentError, /Unable to get a memory view from/)
+        end
       end
 
       it "errors when the memory is out of bounds" do

--- a/spec/unit/memory_spec.rb
+++ b/spec/unit/memory_spec.rb
@@ -92,7 +92,7 @@ module Wasmtime
       it "exposes a frozen string" do
         mem = Memory.new(store, min_size: 3)
         mem.write(0, "foo")
-        str = mem.slice(0, 3).to_s
+        str = String(mem.slice(0, 3))
 
         expect(str).to eq("foo")
         expect(str.encoding).to eq(Encoding::ASCII_8BIT)
@@ -116,7 +116,7 @@ module Wasmtime
         slice = mem.slice(0, 3)
         mem.grow(1)
 
-        expect { slice.to_s }
+        expect { slice.to_str }
           .to raise_error(Wasmtime::Error, "memory slice was invalidated by resize")
         expect { slice.to_memory_view }
           .to raise_error(ArgumentError, /Unable to get a memory view from/)

--- a/spec/unit/memory_spec.rb
+++ b/spec/unit/memory_spec.rb
@@ -99,7 +99,7 @@ module Wasmtime
         expect(str).to be_frozen
       end
 
-      if RUBY_VERSION >= "3.0.0"
+      if defined?(Fiddle::MemoryView)
         it "exposes a memory view" do
           mem = Memory.new(store, min_size: 3)
           mem.write(0, "foo")
@@ -108,7 +108,7 @@ module Wasmtime
           expect(view).to be_a(Fiddle::MemoryView)
           expect(view).to be_readonly
           expect(view.ndim).to eq(1)
-          expect(view.to_s).to eq("foo")
+          expect(view.to_s).to eq("foo") unless RUBY_VERSION.start_with?("3.0")
         end
       end
 
@@ -121,7 +121,7 @@ module Wasmtime
         expect { slice.to_str }
           .to raise_error(Wasmtime::Error, "memory slice was invalidated by resize")
 
-        if RUBY_VERSION >= "3.0.0"
+        if defined?(Fiddle::MemoryView)
           expect { slice.to_memory_view }
             .to raise_error(ArgumentError, /Unable to get a memory view from/)
         end


### PR DESCRIPTION
Currently, reading data from wasm memory always requires `malloc`ing a new buffer. For certain applications, this can become prohibitively expensive. This PR adds a new method (`Memory#slice`), which returns a readonly view of the `Memory` slice. 

The slice can be converted to a [`Fiddle::MemoryView`](https://docs.ruby-lang.org/en/master/memory_view_md.html) or a frozen string. The frozen string essentially re-implements [`Fiddle::MemoryView#to_s`](https://github.com/ruby/fiddle/blob/36b24325754880266bacf49690e09826b30ad30b/ext/fiddle/memory_view.c#L271) which directly uses the memory slice pointer and length to create a `STR_NO_FREE` string, with an associated ivar to prevent GC.

In the implementation, there is a guard that invalidates the slice whenever the memory size changes. In my tests, this check doesn't seem to matter since the slice is addressed in a position-independent way (using offsets). However, I took the conservative approach and included this check anyway since it seems like a sane invariant.

