### PR TITLE
Skip CI & memcheck when pushing v* tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 ---
 name: CI
 
-on: push
+on:
+  push:
+    branches: ["*"]
+    tags-ignore: ["v*"]  # Skip CI for releases
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -15,6 +15,8 @@ on:
           - "3.0"
           - "2.7"
   push:
+    branches: ["*"]
+    tags-ignore: ["v*"]  # Skip Memcheck for releases
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This should not be needed assuming `main` is green. It'll speed up builds and avoid wasting resources.