### PR TITLE
Fix linter

### DIFF
--- a/ext/src/ruby_api/func.rs
+++ b/ext/src/ruby_api/func.rs
@@ -221,7 +221,7 @@ pub fn make_func_closure(
         for (i, param) in params.iter().enumerate() {
             let rparam = param
                 .to_ruby_value(&store_context)
-                .map_err(|e| anyhow::anyhow!(format!("invalid argument at index {}: {}", i, e)))?;
+                .map_err(|e| anyhow::anyhow!(format!("invalid argument at index {i}: {e}")))?;
             rparams.push(rparam).unwrap();
         }
 
@@ -255,7 +255,7 @@ pub fn make_func_closure(
                             *wasm_val = rb_val.to_wasm_val(&ty).map_err(|e| {
                                 Error::new(
                                     result_error(),
-                                    format!("{} (result index {} in {})", e, i, callable),
+                                    format!("{e} (result index {i} in {callable})"),
                                 )
                             })?;
                         }

--- a/ext/src/ruby_api/trap.rs
+++ b/ext/src/ruby_api/trap.rs
@@ -50,7 +50,7 @@ impl Trap {
     ///        0:   0x1a - <unknown>!<wasm function 0>
     /// @return [String, nil]
     pub fn wasm_backtrace_message(&self) -> Option<String> {
-        self.wasm_backtrace.as_ref().map(|bt| format!("{}", bt))
+        self.wasm_backtrace.as_ref().map(|bt| format!("{bt}"))
     }
 
     /// @yard


### PR DESCRIPTION
I don't know what changed but the linter started complaining about  `{}` placeholders in `format!`. That's why CI is failing on main.

This PR fixes that.