### PR TITLE
Ensure source gem builds properly for `cdylib`

### DIFF
--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -4,7 +4,7 @@ name: Build gems
 on:
   workflow_dispatch:
   push:
-    branches: ["main", "cross-gem/*"]
+    branches: ["main", "cross-gem/*", "pkg/*"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -71,14 +71,9 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-          cargo-cache: true
+          cargo-cache: false
           cache-version: v1
 
       - name: Smoke test gem install
         shell: bash
-        run: |
-          bundle exec rake build
-          gem install pkg/wasmtime-*.gem --verbose
-          script="puts Wasmtime::Engine.new.precompile_module('(module)')"
-          ruby -rwasmtime -e "$script" | grep wasmtime.info
-          echo "✅ Successfully gem installed"
+        run: bundle exec rake pkg:ruby:test

--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
           ruby-version: "3.1"
-          bundler-cache: false
+          bundler-cache: true
           cargo-cache: true
           cargo-vendor: true
           cache-version: v1-${{ matrix.ruby-platform }}

--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set vars
         id: vars
         run: |
-          echo "rb-sys-version=$(ruby -rrb_sys -e 'puts RbSys::VERSION')" >> $GITHUB_OUTPUT
+          echo "rb-sys-version=$(bundle exec ruby -rrb_sys -e 'puts RbSys::VERSION')" >> $GITHUB_OUTPUT
 
       - uses: oxidize-rb/cross-gem-action@main
         with:

--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -41,21 +41,22 @@ jobs:
           bundler-cache: false
           cargo-cache: true
           cargo-vendor: true
-          cache-version: v0-${{ matrix.ruby-platform }}
+          cache-version: v1-${{ matrix.ruby-platform }}
+
+      - name: Set vars
+        id: vars
+        run: |
+          echo "rb-sys-version=$(ruby -rrb_sys -e 'puts RbSys::VERSION')" >> $GITHUB_OUTPUT
 
       - uses: oxidize-rb/cross-gem-action@main
         with:
-          version: latest
+          version: ${{ steps.vars.outputs.rb-sys-version }}
           platform: ${{ matrix.ruby-platform }}
           ruby-versions: ${{ join(fromJSON(needs.ci-data.outputs.result).stable-ruby-versions, ', ') }}
 
       - name: Smoke gem install
         if: matrix.ruby-platform == 'x86_64-linux' # GitHub actions architecture
-        run: |
-          gem install pkg/wasmtime-*.gem --verbose
-          script="puts Wasmtime::Engine.new.precompile_module('(module)')"
-          ruby -rwasmtime -e "$script" | grep wasmtime.info
-          echo "✅ Successfully gem installed"
+        run: bundle exec rake pkg:${{ matrix.ruby-platform }}:test
 
   source:
     name: Build source gem

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,18 +1069,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.58"
+version = "0.9.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0158f5115e1ad04a2ee231f597e86306af96f36a8b93ac0c01f8852d0ba89278"
+checksum = "e2124104eebed77513bd4bb8fa02b6c07d376f5061723f9ae6888d099cd76b5e"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.58"
+version = "0.9.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c27b779db4a2863db74ddad0011f0d0c55c528e9601126d4613ad688063bc05"
+checksum = "4184e095ac104676122290a570bdeaa402d5e9c1e6cc639ecb33f9757ee33ddd"
 dependencies = [
  "bindgen",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,18 +1069,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.59"
+version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2124104eebed77513bd4bb8fa02b6c07d376f5061723f9ae6888d099cd76b5e"
+checksum = "128fe32bdc31f5788263d945d32ffd71855c22d0950a2946d0cce512640bcd58"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.59"
+version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4184e095ac104676122290a570bdeaa402d5e9c1e6cc639ecb33f9757ee33ddd"
+checksum = "f3ab6ad065389873cf9ffbcab4d7d1ef3c7755b002b6bf79bf0374ce119a6977"
 dependencies = [
  "bindgen",
  "regex",

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gemspec
 group :development do
   gem "rake", "~> 13.0"
   gem "rake-compiler"
-  gem "rb_sys"
+  gem "rb_sys", "~> 0.9.59"
   gem "standard", "~> 1.22"
   gem "get_process_mem"
   gem "ruby-lsp", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     wasmtime (5.0.0)
-      rb_sys (~> 0.9.48)
+      rb_sys (~> 0.9.59)
 
 GEM
   remote: https://rubygems.org/
@@ -11,6 +11,8 @@ GEM
     benchmark-ips (2.10.0)
     diff-lcs (1.5.0)
     ffi (1.15.5)
+    ffi (1.15.5-x64-mingw-ucrt)
+    ffi (1.15.5-x64-mingw32)
     get_process_mem (0.2.7)
       ffi (~> 1.0)
     json (2.6.3)
@@ -23,7 +25,7 @@ GEM
     rake (13.0.6)
     rake-compiler (1.2.1)
       rake
-    rb_sys (0.9.58)
+    rb_sys (0.9.59)
     regexp_parser (2.6.2)
     rexml (3.2.5)
     rspec (3.12.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     wasmtime (5.0.0)
-      rb_sys (~> 0.9.59)
+      rb_sys (~> 0.9.60)
 
 GEM
   remote: https://rubygems.org/
@@ -25,7 +25,7 @@ GEM
     rake (13.0.6)
     rake-compiler (1.2.1)
       rake
-    rb_sys (0.9.59)
+    rb_sys (0.9.60)
     regexp_parser (2.6.2)
     rexml (3.2.5)
     rspec (3.12.0)
@@ -89,7 +89,7 @@ DEPENDENCIES
   get_process_mem
   rake (~> 13.0)
   rake-compiler
-  rb_sys
+  rb_sys (~> 0.9.59)
   rspec (~> 3.1)
   ruby-lsp
   standard (~> 1.22)
@@ -98,4 +98,4 @@ DEPENDENCIES
   yard-rustdoc (~> 0.3.2)
 
 BUNDLED WITH
-   2.3.24
+   2.4.3

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -16,7 +16,7 @@ ruby-api = []
 [dependencies]
 lazy_static = "1.4.0"
 magnus = { version = "0.4", features = ["rb-sys-interop"] }
-rb-sys = "~0.9.58"
+rb-sys = "~0.9.60"
 wasmtime = "5.0.0"
 wasmtime-wasi = "5.0.0"
 wasi-common = "5.0.0"

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -3,4 +3,7 @@
 require "mkmf"
 require "rb_sys/mkmf"
 
-create_rust_makefile("wasmtime/wasmtime_rb")
+create_rust_makefile("wasmtime/wasmtime_rb") do |ext|
+  ext.extra_cargo_args += ["--crate-type", "cdylib"]
+  ext.extra_cargo_args += ["--package", "wasmtime-rb"]
+end

--- a/rakelib/compile.rake
+++ b/rakelib/compile.rake
@@ -8,7 +8,6 @@ Rake::ExtensionTask.new("wasmtime_rb", GEMSPEC) do |ext|
   ext.ext_dir = "ext"
   ext.cross_compile = !CROSS_PLATFORMS.empty?
   ext.cross_platform = CROSS_PLATFORMS
-  ext.config_options << "--crate-type=cdylib"
 
   ext.cross_compiling do |gem_spec|
     # No need for rb_sys to compile

--- a/wasmtime.gemspec
+++ b/wasmtime.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = "https://github.com/BytecodeAlliance/wasmtime-rb"
   spec.metadata["source_code_uri"] = "https://github.com/BytecodeAlliance/wasmtime-rb"
-  spec.metadata["cargo_crate_name"] = "ext"
+  spec.metadata["cargo_crate_name"] = "wasmtime-rb"
   spec.metadata["changelog_uri"] = "https://github.com/bytecodealliance/wasmtime-rb/blob/main/CHANGELOG.md"
 
   spec.files = Dir["{lib,ext}/**/*", "LICENSE", "README.md", "Cargo.*"]
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.rdoc_options += ["--exclude", "vendor"]
 
   # Can be removed for binary gems and rubygems >= 3.3.24
-  spec.add_dependency "rb_sys", "~> 0.9.48"
+  spec.add_dependency "rb_sys", "~> 0.9.59"
 end

--- a/wasmtime.gemspec
+++ b/wasmtime.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.rdoc_options += ["--exclude", "vendor"]
 
   # Can be removed for binary gems and rubygems >= 3.3.24
-  spec.add_dependency "rb_sys", "~> 0.9.59"
+  spec.add_dependency "rb_sys", "~> 0.9.60"
 end


### PR DESCRIPTION
#121 unintentionally broke source gem compilation due to changes with how `crate-type` was specified. This PR fixes it with an upgrade `rb-sys v0.9.59`.