### PR TITLE
Tweak codegen flags for optimized, profile-able builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,6 @@ members = ["ext"]
 exclude = ["examples/rust-crate"]
 
 [profile.release]
-codegen-units = 1
-debug = 1
-strip = true
+codegen-units = 1 # more llvm optimizations
+debug = 2 # make perfomance engineers happy
+lto = "thin" # cross-crate inlining


### PR DESCRIPTION
As the title hints, this PR adjusts the codegen options for release builds. The perf numbers look pretty good, but [still need to make sure the config works during cross compilation](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/4078833559). Hopefully there are no linking issues.

As for removing the `strip` and upping the `debuginfo`, this resulted in about a 28% larger binary (15mb vs 20mb). I think this tradeoff is absolutely worth it, since it allows profiling tools and debuggers to work seamlessly. Plus, all of the data gets `gzip`'d when downloading the gem, anyway. At load time, the debug sections are not loaded into memory by `ld` either.

### Data

```diff
--- tmp/old.txt	2023-02-02 16:22:27
+++ tmp/lto.txt	2023-02-02 16:19:04
@@ -1,37 +1,38 @@
 ruby -Ilib bench/compile.rb
 Warming up --------------------------------------
-        empty module     2.009k i/100ms
+        empty module     1.993k i/100ms
 Calculating -------------------------------------
-        empty module     18.005k (±10.0%) i/s -     90.405k in   5.075999s
+        empty module     20.770k (± 3.4%) i/s -    105.629k in   5.092696s
 
 ruby -Ilib bench/func_call.rb
 Warming up --------------------------------------
-     Instance#invoke   252.481k i/100ms
-           Func#call   302.268k i/100ms
+     Instance#invoke   267.031k i/100ms
+           Func#call   329.738k i/100ms
 Calculating -------------------------------------
-     Instance#invoke      2.506M (± 1.0%) i/s -     12.624M in   5.038728s
-           Func#call      3.021M (± 2.9%) i/s -     15.113M in   5.007714s
+     Instance#invoke      2.599M (± 4.5%) i/s -     13.085M in   5.044271s
+           Func#call      3.264M (± 3.0%) i/s -     16.487M in   5.055698s
 
 Comparison:
-           Func#call:  3020706.5 i/s
-     Instance#invoke:  2505663.3 i/s - 1.21x  (± 0.00) slower
+           Func#call:  3264018.9 i/s
+     Instance#invoke:  2599130.6 i/s - 1.26x  (± 0.00) slower
 
 
 ruby -Ilib bench/host_call.rb
 Warming up --------------------------------------
-      Call host func    34.049k i/100ms
+      Call host func    35.277k i/100ms
 Calculating -------------------------------------
-      Call host func    334.396k (± 2.3%) i/s -      1.702M in   5.093870s
+      Call host func    348.356k (± 3.3%) i/s -      1.764M in   5.068869s
 
 ruby -Ilib bench/instantiate.rb
 Warming up --------------------------------------
-  Linker#instantiate    71.859k i/100ms
-        Instance#new    68.706k i/100ms
+  Linker#instantiate    77.557k i/100ms
+        Instance#new    72.122k i/100ms
 Calculating -------------------------------------
-  Linker#instantiate    731.344k (± 2.9%) i/s -      3.665M in   5.015378s
-        Instance#new    649.466k (± 4.8%) i/s -      3.298M in   5.089981s
+  Linker#instantiate    759.669k (± 2.9%) i/s -      3.800M in   5.006740s
+        Instance#new    721.101k (± 4.3%) i/s -      3.606M in   5.010205s
 
 Comparison:
-  Linker#instantiate:   731344.2 i/s
-        Instance#new:   649466.4 i/s - 1.13x  (± 0.00) slower
+  Linker#instantiate:   759668.6 i/s
+        Instance#new:   721101.2 i/s - same-ish: difference falls within error
+
```
