### PR TITLE
Fix the build on Ruby < 3.0

### DIFF
--- a/ext/src/ruby_api/memory/unsafe_slice.rs
+++ b/ext/src/ruby_api/memory/unsafe_slice.rs
@@ -1,8 +1,8 @@
 use crate::{define_data_class, define_rb_intern, error, Memory};
 #[cfg(ruby_gte_3_0)]
-use magnus::{class::object, gc, require, RModule};
+use magnus::{class::object, require, RModule};
 use magnus::{
-    memoize, method,
+    gc, memoize, method,
     rb_sys::{AsRawId, AsRawValue, FromRawValue},
     typed_data::DataTypeBuilder,
     typed_data::Obj,


### PR DESCRIPTION
Introduced in #138 by mistake.

It made its way to main because I unintentionally merged without waiting for the build. The checks didn't start, and in trying to debug, I disabled and re-enabled the checks. As the checks were disabled, auto-merge kicked in and merged the PR.

Really gotta figure out why the build sometimes does not start.