### PR TITLE
Reduce dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
May I suggest running dependabot less frequently. It's tricky to follow progress in a repo running dependabot 52 times a year. The commit logs are have bad signal/noise ratio.

You'll also spend only 1/4 of the time merging them.

Monthly is still frequent enough to gain all the benefits.