### PR TITLE
Fix rb-sys build warning

### DIFF
--- a/wasmtime.gemspec
+++ b/wasmtime.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{lib,ext}/**/*", "LICENSE", "README.md", "Cargo.*"]
   spec.files.reject! { |f| File.directory?(f) }
+  spec.files.reject! { |f| f =~ /\.(dll|so|dylib|lib|bundle)\Z/ }
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
The gemspec's file list currently include all files, including native
extensions. We thus get the following warning:

>⚠️ gemspec includes native artifact (lib/wasmtime/ext.bundle), please remove it.
>⚠️ gemspec includes native artifact (lib/wasmtime/wasmtime_rb.bundle), please remove it.

This PR addresses that.
