### PR TITLE
Use Magnus macros to implement TypedData trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "magnus-macros"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85aa71c9891b2732ff1157e1860a1ee578459fd25811fd3d72cc6e32b3fbdfea"
+checksum = "6cc17af1d45442c011aa579d727ec6cff8a69aea8a6bbad26736e7112d749bfb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ext/src/helpers/macros.rs
+++ b/ext/src/helpers/macros.rs
@@ -10,18 +10,3 @@ macro_rules! define_rb_intern {
         )*
     };
 }
-
-/// Define a Ruby class for a `TypedData` Struct in the given namespace,
-/// with the specified base class (optional, defaults to `::Object`).
-/// Also undef the alloc function to avoid warnings on Ruby 3.2+.
-#[macro_export]
-macro_rules! define_data_class {
-    ($namespace:expr, $name:expr, $parent:expr) => {{
-        let class = $namespace.define_class($name, $parent).unwrap();
-        magnus::Class::undef_alloc_func(class);
-        class
-    }};
-    ($namespace:expr, $name:expr) => {
-        define_data_class!($namespace, $name, magnus::RClass::default())
-    };
-}

--- a/ext/src/ruby_api/caller.rs
+++ b/ext/src/ruby_api/caller.rs
@@ -1,9 +1,6 @@
 use super::{convert::WrapWasmtimeType, externals::Extern, root, store::StoreData};
-use crate::{define_data_class, error};
-use magnus::{
-    memoize, method, typed_data::DataTypeBuilder, typed_data::Obj, DataTypeFunctions, Error,
-    Module as _, RClass, RString, TypedData, Value, QNIL,
-};
+use crate::error;
+use magnus::{method, typed_data::Obj, Error, Module as _, RString, Value, QNIL};
 use std::cell::UnsafeCell;
 use wasmtime::{AsContext, AsContextMut, Caller as CallerImpl, StoreContext, StoreContextMut};
 
@@ -46,6 +43,7 @@ impl<'a> CallerHandle<'a> {
 /// block argument in {Func.new}).
 /// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Caller.html Wasmtime's Rust doc
 #[derive(Debug)]
+#[magnus::wrap(class = "Wasmtime::Caller", free_immediately, unsafe_generics)]
 pub struct Caller<'a> {
     handle: CallerHandle<'a>,
 }
@@ -116,22 +114,6 @@ impl<'a> Caller<'a> {
         self.handle.expire();
     }
 }
-
-unsafe impl<'a> TypedData for Caller<'a> {
-    fn class() -> magnus::RClass {
-        *memoize!(RClass: define_data_class!(root(), "Caller"))
-    }
-
-    fn data_type() -> &'static magnus::DataType {
-        memoize!(magnus::DataType: {
-            let mut builder = DataTypeBuilder::<Caller<'_>>::new("Wasmtime::Caller");
-            builder.free_immediately();
-            builder.build()
-        })
-    }
-}
-
-impl DataTypeFunctions for Caller<'_> {}
 
 unsafe impl Send for Caller<'_> {}
 

--- a/ext/src/ruby_api/externals.rs
+++ b/ext/src/ruby_api/externals.rs
@@ -2,37 +2,29 @@ use super::{
     convert::WrapWasmtimeType, func::Func, global::Global, memory::Memory, root,
     store::StoreContextValue, table::Table,
 };
-use crate::{conversion_err, define_data_class, not_implemented};
+use crate::{conversion_err, not_implemented};
 use magnus::{
-    gc, memoize, method, rb_sys::AsRawValue, typed_data::DataTypeBuilder, typed_data::Obj,
-    DataTypeFunctions, Error, Module, RClass, TypedData, Value,
+    gc, method, rb_sys::AsRawValue, typed_data::Obj, DataTypeFunctions, Error, Module, RClass,
+    TypedData, Value,
 };
 
 /// @yard
 /// @rename Wasmtime::Extern
 /// An external item to a WebAssembly module, or a list of what can possibly be exported from a Wasm module.
 /// @see https://docs.rs/wasmtime/latest/wasmtime/enum.Extern.html Wasmtime's Rust doc
+#[derive(TypedData)]
+#[magnus(
+    class = "Wasmtime::Extern",
+    size,
+    mark,
+    free_immediately,
+    unsafe_generics
+)]
 pub enum Extern<'a> {
     Func(Obj<Func<'a>>),
     Global(Obj<Global<'a>>),
     Memory(Obj<Memory<'a>>),
     Table(Obj<Table<'a>>),
-}
-
-unsafe impl TypedData for Extern<'_> {
-    fn class() -> magnus::RClass {
-        *memoize!(RClass: define_data_class!(root(), "Extern"))
-    }
-
-    fn data_type() -> &'static magnus::DataType {
-        memoize!(magnus::DataType: {
-            let mut builder = DataTypeBuilder::<Extern<'_>>::new("Wasmtime::Extern");
-            builder.size();
-            builder.mark();
-            builder.free_immediately();
-            builder.build()
-        })
-    }
 }
 
 impl DataTypeFunctions for Extern<'_> {

--- a/ext/src/ruby_api/func.rs
+++ b/ext/src/ruby_api/func.rs
@@ -5,11 +5,10 @@ use super::{
     root,
     store::{Store, StoreContextValue, StoreData},
 };
-use crate::{define_data_class, Caller};
+use crate::Caller;
 use magnus::{
-    block::Proc, function, memoize, method, scan_args::scan_args, typed_data::DataTypeBuilder,
-    typed_data::Obj, DataTypeFunctions, Error, Module as _, Object, RArray, RClass, TypedData,
-    Value, QNIL,
+    block::Proc, function, method, scan_args::scan_args, typed_data::Obj, DataTypeFunctions, Error,
+    Module as _, Object, RArray, TypedData, Value, QNIL,
 };
 use wasmtime::{Caller as CallerImpl, Func as FuncImpl, Val};
 
@@ -17,26 +16,17 @@ use wasmtime::{Caller as CallerImpl, Func as FuncImpl, Val};
 /// @rename Wasmtime::Func
 /// Represents a WebAssembly Function
 /// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Func.html Wasmtime's Rust doc
-#[derive(Debug)]
+#[derive(Debug, TypedData)]
+#[magnus(
+    class = "Wasmtime::Func",
+    size,
+    mark,
+    free_immediately,
+    unsafe_generics
+)]
 pub struct Func<'a> {
     store: StoreContextValue<'a>,
     inner: FuncImpl,
-}
-
-unsafe impl<'a> TypedData for Func<'a> {
-    fn class() -> magnus::RClass {
-        *memoize!(RClass: define_data_class!(root(), "Func"))
-    }
-
-    fn data_type() -> &'static magnus::DataType {
-        memoize!(magnus::DataType: {
-            let mut builder = DataTypeBuilder::<Func<'_>>::new("Wasmtime::Func");
-            builder.size();
-            builder.mark();
-            builder.free_immediately();
-            builder.build()
-        })
-    }
 }
 
 impl DataTypeFunctions for Func<'_> {

--- a/ext/src/ruby_api/global.rs
+++ b/ext/src/ruby_api/global.rs
@@ -3,10 +3,10 @@ use super::{
     root,
     store::{Store, StoreContextValue},
 };
-use crate::{define_data_class, error};
+use crate::error;
 use magnus::{
-    function, memoize, method, typed_data::DataTypeBuilder, typed_data::Obj, DataTypeFunctions,
-    Error, Module as _, Object, RClass, Symbol, TypedData, Value,
+    function, method, typed_data::Obj, DataTypeFunctions, Error, Module as _, Object, Symbol,
+    TypedData, Value,
 };
 use wasmtime::{Extern, Global as GlobalImpl, GlobalType, Mutability};
 
@@ -14,25 +14,11 @@ use wasmtime::{Extern, Global as GlobalImpl, GlobalType, Mutability};
 /// @rename Wasmtime::Global
 /// Represents a WebAssembly global.
 /// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Global.html Wasmtime's Rust doc
-#[derive(Debug)]
+#[derive(Debug, TypedData)]
+#[magnus(class = "Wasmtime::Global", free_immediately, mark, unsafe_generics)]
 pub struct Global<'a> {
     store: StoreContextValue<'a>,
     inner: GlobalImpl,
-}
-
-unsafe impl TypedData for Global<'_> {
-    fn class() -> magnus::RClass {
-        *memoize!(RClass: define_data_class!(root(), "Global"))
-    }
-
-    fn data_type() -> &'static magnus::DataType {
-        memoize!(magnus::DataType: {
-            let mut builder = DataTypeBuilder::<Global<'_>>::new("Wasmtime::Global");
-            builder.free_immediately();
-            builder.mark();
-            builder.build()
-        })
-    }
 }
 
 impl DataTypeFunctions for Global<'_> {

--- a/ext/src/ruby_api/table.rs
+++ b/ext/src/ruby_api/table.rs
@@ -3,10 +3,10 @@ use super::{
     root,
     store::{Store, StoreContextValue},
 };
-use crate::{define_data_class, define_rb_intern, error};
+use crate::{define_rb_intern, error};
 use magnus::{
-    function, memoize, method, scan_args, typed_data::DataTypeBuilder, typed_data::Obj,
-    DataTypeFunctions, Error, Module as _, Object, RClass, Symbol, TypedData, Value, QNIL,
+    function, method, scan_args, typed_data::Obj, DataTypeFunctions, Error, Module as _, Object,
+    Symbol, TypedData, Value, QNIL,
 };
 use wasmtime::{Extern, Table as TableImpl, TableType};
 
@@ -19,25 +19,11 @@ define_rb_intern!(
 /// @rename Wasmtime::Table
 /// Represents a WebAssembly table.
 /// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Table.html Wasmtime's Rust doc
-#[derive(Debug)]
+#[derive(Debug, TypedData)]
+#[magnus(class = "Wasmtime::Table", free_immediately, mark, unsafe_generics)]
 pub struct Table<'a> {
     store: StoreContextValue<'a>,
     inner: TableImpl,
-}
-
-unsafe impl TypedData for Table<'_> {
-    fn class() -> magnus::RClass {
-        *memoize!(RClass: define_data_class!(root(), "Table"))
-    }
-
-    fn data_type() -> &'static magnus::DataType {
-        memoize!(magnus::DataType: {
-            let mut builder = DataTypeBuilder::<Table<'_>>::new("Wasmtime::Table");
-            builder.free_immediately();
-            builder.mark();
-            builder.build()
-        })
-    }
 }
 
 impl DataTypeFunctions for Table<'_> {


### PR DESCRIPTION
This library is a great stress test for Magnus' API, so I've been trying out some Magnus API changes to see how they fair in use.

While I was doing that I noticed there's a lot of implementations of `TypedData` that are near identical to what would be derived.

Magnus doesn't usually allow deriving `TypedData` for types with generics as the derived implementation isn't guaranteed to be correct, and I don't want people trying it, find it compiles, and then hit nasty segfaults.

However, it seems mean to make you write out exactly what the macro would produce, so I [added an `unsafe_generics` attribute][commit] to bypass the error, and I've back ported it to the current release branch of the magnus-macros crate.

The changes here remove the `TypedData` implementations in favour of the macros with the `unsafe_generics` attribute set.

[commit]: https://github.com/matsadler/magnus/commit/90454ff8320ef8d5b03e196a843188e32ce16be2