### PR TITLE
Mark the Gem as Ractor safe

### DIFF
--- a/ext/src/lib.rs
+++ b/ext/src/lib.rs
@@ -10,6 +10,7 @@ pub(crate) use ruby_api::*;
 
 #[magnus::init]
 pub fn init() -> Result<(), Error> {
+    #[cfg(ruby_gte_3_0)]
     unsafe { rb_sys::rb_ext_ractor_safe(true); }
     ruby_api::init()
 }

--- a/ext/src/lib.rs
+++ b/ext/src/lib.rs
@@ -11,6 +11,8 @@ pub(crate) use ruby_api::*;
 #[magnus::init]
 pub fn init() -> Result<(), Error> {
     #[cfg(ruby_gte_3_0)]
-    unsafe { rb_sys::rb_ext_ractor_safe(true); }
+    unsafe {
+        rb_sys::rb_ext_ractor_safe(true);
+    }
     ruby_api::init()
 }

--- a/ext/src/lib.rs
+++ b/ext/src/lib.rs
@@ -10,5 +10,6 @@ pub(crate) use ruby_api::*;
 
 #[magnus::init]
 pub fn init() -> Result<(), Error> {
+    unsafe { rb_sys::rb_ext_ractor_safe(true); }
     ruby_api::init()
 }

--- a/spec/integration/ractor_spec.rb
+++ b/spec/integration/ractor_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe "Ractor" do
+  it "supports running inside Ractors" do
+    wat = <<~WAT
+      (module
+        (func $module/hello (result i32 i64 f32 f64)
+          i32.const 1
+          i64.const 2
+          f32.const 3.0
+          f64.const 4.0
+        )
+
+        (export "hello" (func $module/hello))
+      )
+    WAT
+
+    r = Ractor.new(wat) do |wat|
+      engine = Wasmtime::Engine.new
+      mod = Wasmtime::Module.new(engine, wat)
+      store_data = Object.new
+      store = Wasmtime::Store.new(engine, store_data)
+      Wasmtime::Instance.new(store, mod).invoke("hello")
+    end
+
+    result = r.take
+    expect(result).to eq([1, 2, 3.0, 4.0])
+  end
+end

--- a/spec/integration/ractor_spec.rb
+++ b/spec/integration/ractor_spec.rb
@@ -1,27 +1,29 @@
-RSpec.describe "Ractor" do
-  it "supports running inside Ractors" do
-    wat = <<~WAT
-      (module
-        (func $module/hello (result i32 i64 f32 f64)
-          i32.const 1
-          i64.const 2
-          f32.const 3.0
-          f64.const 4.0
+if RUBY_VERSION.start_with?("3.")
+  RSpec.describe "Ractor" do
+    it "supports running inside Ractors" do
+      wat = <<~WAT
+        (module
+          (func $module/hello (result i32 i64 f32 f64)
+            i32.const 1
+            i64.const 2
+            f32.const 3.0
+            f64.const 4.0
+          )
+
+          (export "hello" (func $module/hello))
         )
+      WAT
 
-        (export "hello" (func $module/hello))
-      )
-    WAT
+      r = Ractor.new(wat) do |wat|
+        engine = Wasmtime::Engine.new
+        mod = Wasmtime::Module.new(engine, wat)
+        store_data = Object.new
+        store = Wasmtime::Store.new(engine, store_data)
+        Wasmtime::Instance.new(store, mod).invoke("hello")
+      end
 
-    r = Ractor.new(wat) do |wat|
-      engine = Wasmtime::Engine.new
-      mod = Wasmtime::Module.new(engine, wat)
-      store_data = Object.new
-      store = Wasmtime::Store.new(engine, store_data)
-      Wasmtime::Instance.new(store, mod).invoke("hello")
+      result = r.take
+      expect(result).to eq([1, 2, 3.0, 4.0])
     end
-
-    result = r.take
-    expect(result).to eq([1, 2, 3.0, 4.0])
   end
 end


### PR DESCRIPTION
Just need to call `rb_ext_ractor_safe` in `init`.

An extension is Ractor safe if it has no global variables.

See https://docs.ruby-lang.org/en/master/extension_rdoc.html#label-Appendix+F.+Ractor+support

Note that all objects have to be created inside the Ractor, as the engine, store, etc. are not shareable (yet?). But it works!