### PR TITLE
Allowing making Module and Engine Ractor shareable

### DIFF
--- a/ext/src/ruby_api/engine.rs
+++ b/ext/src/ruby_api/engine.rs
@@ -16,7 +16,7 @@ lazy_static::lazy_static! {
 /// @yard
 /// Represents a Wasmtime execution engine.
 /// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Engine.html Wasmtime's Rust doc
-#[magnus::wrap(class = "Wasmtime::Engine", free_immediately)]
+#[magnus::wrap(class = "Wasmtime::Engine", free_immediately, frozen_shareable)]
 pub struct Engine {
     inner: EngineImpl,
 

--- a/ext/src/ruby_api/engine.rs
+++ b/ext/src/ruby_api/engine.rs
@@ -1,7 +1,7 @@
-use std::sync::Mutex;
 use super::{config::hash_to_config, root};
 use crate::error;
 use magnus::{function, method, scan_args, Error, Module, Object, RHash, RString, Value};
+use std::sync::Mutex;
 use wasmtime::Engine as EngineImpl;
 
 #[cfg(feature = "tokio")]

--- a/ext/src/ruby_api/module.rs
+++ b/ext/src/ruby_api/module.rs
@@ -7,7 +7,7 @@ use wasmtime::Module as ModuleImpl;
 /// Represents a WebAssembly module.
 /// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Module.html Wasmtime's Rust doc
 #[derive(Clone)]
-#[magnus::wrap(class = "Wasmtime::Module", size, free_immediatly)]
+#[magnus::wrap(class = "Wasmtime::Module", size, free_immediatly, frozen_shareable)]
 pub struct Module {
     inner: ModuleImpl,
 }

--- a/spec/integration/ractor_spec.rb
+++ b/spec/integration/ractor_spec.rb
@@ -33,14 +33,18 @@ if RUBY_VERSION.start_with?("3.")
       Ractor.make_shareable(engine)
       Ractor.make_shareable(mod)
 
-      r = Ractor.new(engine, mod) do |engine, mod|
-        store_data = Object.new
-        store = Wasmtime::Store.new(engine, store_data)
-        Wasmtime::Instance.new(store, mod).invoke("hello")
+      ractors = []
+      3.times do
+        ractors << Ractor.new(engine, mod) do |engine, mod|
+          store_data = Object.new
+          store = Wasmtime::Store.new(engine, store_data)
+          Wasmtime::Instance.new(store, mod).invoke("hello")
+        end
       end
 
-      result = r.take
-      expect(result).to eq([1, 2, 3.0, 4.0])
+      ractors.each do |ractor|
+        expect(ractor.take).to eq([1, 2, 3.0, 4.0])
+      end
     end
   end
 end

--- a/spec/integration/ractor_spec.rb
+++ b/spec/integration/ractor_spec.rb
@@ -1,22 +1,39 @@
 if RUBY_VERSION.start_with?("3.")
   RSpec.describe "Ractor" do
-    it "supports running inside Ractors" do
-      wat = <<~WAT
-        (module
-          (func $module/hello (result i32 i64 f32 f64)
-            i32.const 1
-            i64.const 2
-            f32.const 3.0
-            f64.const 4.0
-          )
-
-          (export "hello" (func $module/hello))
+    let(:wat) { <<~WAT }
+      (module
+        (func $module/hello (result i32 i64 f32 f64)
+          i32.const 1
+          i64.const 2
+          f32.const 3.0
+          f64.const 4.0
         )
-      WAT
 
+        (export "hello" (func $module/hello))
+      )
+    WAT
+
+    it "supports running inside Ractors" do
       r = Ractor.new(wat) do |wat|
         engine = Wasmtime::Engine.new
         mod = Wasmtime::Module.new(engine, wat)
+        store_data = Object.new
+        store = Wasmtime::Store.new(engine, store_data)
+        Wasmtime::Instance.new(store, mod).invoke("hello")
+      end
+
+      result = r.take
+      expect(result).to eq([1, 2, 3.0, 4.0])
+    end
+
+    it "supports sharing Engine & Module with Ractors" do
+      engine = Wasmtime::Engine.new
+      mod = Wasmtime::Module.new(engine, wat)
+
+      Ractor.make_shareable(engine)
+      Ractor.make_shareable(mod)
+
+      r = Ractor.new(engine, mod) do |engine, mod|
         store_data = Object.new
         store = Wasmtime::Store.new(engine, store_data)
         Wasmtime::Instance.new(store, mod).invoke("hello")


### PR DESCRIPTION
Allows:

```ruby
Ractor.make_shareable(engine)
Ractor.make_shareable(mod)
```

So engine and module can be shared between Ractors:

```ruby
r = Ractor.new(engine, mod) do |engine, mod|
  store_data = Object.new
  store = Wasmtime::Store.new(engine, store_data)
  Wasmtime::Instance.new(store, mod).invoke("hello")
end
```