### PR TITLE
Fix potential GC bug when expiring the caller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
 
       - name: Run ruby tests (hard-mode with GC.stress)
         run: bundle exec rake spec
-        if: matrix.os != 'macos-latest' # these specs are aborting on CI with no logs, maybe OOM killer?
         env:
           GC_STRESS: "true"
 

--- a/ext/src/ruby_api/func.rs
+++ b/ext/src/ruby_api/func.rs
@@ -202,7 +202,6 @@ pub fn make_func_closure(
 
     move |caller_impl: CallerImpl<'_, StoreData>, params: &[Val], results: &mut [Val]| {
         let wrapped_caller = Obj::wrap(Caller::new(caller_impl));
-        let caller = wrapped_caller.get();
         let store_context = StoreContextValue::from(wrapped_caller);
 
         let rparams = RArray::with_capacity(params.len() + 1);
@@ -257,7 +256,7 @@ pub fn make_func_closure(
 
         // Drop the wasmtime::Caller so it does not outlive the Func call, if e.g. the user
         // assigned the Ruby Wasmtime::Caller instance to a global.
-        caller.expire();
+        wrapped_caller.get().expire();
 
         result
     }


### PR DESCRIPTION
The compiler may not keep the Caller's VALUE on the stack as we're not using it explicitly. Object allocations can thus cause the Caller to get GC'd, resulting in a segfault when we later try to `expire` it.

See https://github.com/bytecodealliance/wasmtime-rb/issues/156#issuecomment-1491890663 and #158 for investigation.

Fixes #156