### PR TITLE
chore(ext): Update extension crate authors

### DIFF
--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasmtime-rb"
 version = "0.1.0"
 edition = "2021"
-authors = ["Ian Ker-Seymer <hello@ianks.com>"]
+authors = ["The Wasmtime Project Developers"]
 license = "Apache-2.0"
 publish = false
 build = "build.rs"


### PR DESCRIPTION
So that it matches the authors defined in the Gem specification.