### PR TITLE
chore(pkg): Fix permissions of vendored files

### DIFF
--- a/rakelib/pkg.rake
+++ b/rakelib/pkg.rake
@@ -75,9 +75,13 @@ namespace :pkg do
       mkdir_p ".cargo"
       sh "cargo vendor --versioned-dirs --locked #{vendor_dir} >> #{cargo_config_path} 2>/dev/null"
 
-      final_gemspec.files += dirglob("**/.cargo/**/*")
-      final_gemspec.files += dirglob("./#{vendor_dir}/**/*")
-      final_gemspec.files.reject! { |f| File.directory?(f) }
+      vendor_files = dirglob("./#{vendor_dir}/**/*").reject { |f| File.directory?(f) }
+      # Ensure that all vendor files have the right read permissions,
+      # which are needed to build the gem.
+      # The permissions that we want are `.rw-r--r--`
+      vendor_files.each { |f| File.chmod(0o644, f) }
+      final_gemspec.files += vendor_files
+      final_gemspec.files += dirglob("**/.cargo/**/*").reject { |f| File.directory?(f) }
 
       puts "Building gem to #{unpacked_dir}.gem..."
       Gem::Package.build(final_gemspec, false, true, "#{slug}.gem")

--- a/rakelib/pkg.rake
+++ b/rakelib/pkg.rake
@@ -78,8 +78,8 @@ namespace :pkg do
       vendor_files = dirglob("./#{vendor_dir}/**/*").reject { |f| File.directory?(f) }
       # Ensure that all vendor files have the right read permissions,
       # which are needed to build the gem.
-      # The permissions that we want are `.rw-r--r--`
-      vendor_files.each { |f| File.chmod(0o644, f) }
+      # The permissions that we want _at least_ is readable by all for example `.rw-r--r--`
+      vendor_files.each { |f| FileUtils.chmod("a+r", f) }
       final_gemspec.files += vendor_files
       final_gemspec.files += dirglob("**/.cargo/**/*").reject { |f| File.directory?(f) }
 


### PR DESCRIPTION
This commit ensures that all vendored files have the right permissions needed to build the gem.

The expected permissions are: `rw-r--r--`.

This issue was surfaced in
https://github.com/bytecodealliance/wasmtime-rb/actions/runs/4596038198/jobs/8117624399, in which a dependency update likely introduced an unexpected permission change in its files.

Locally inspecting the vendored files shows the discrepancy: the majority of the dependencies have the following permissions:

```
rw-r--r-- 1.2k saulecabrera  3 Apr 11:12 build.rs
.rw-r--r-- 1.5k saulecabrera  3 Apr 11:12 Cargo.toml
.rw-r--r--  869 saulecabrera  3 Apr 11:12 COPYRIGHT
.rw-r--r--  11k saulecabrera  3 Apr 11:12 LICENSE-APACHE
.rw-r--r--  12k saulecabrera  3 Apr 11:12 LICENSE-Apache-2.0_WITH_LLVM-exception
.rw-r--r-- 1.0k saulecabrera  3 Apr 11:12 LICENSE-MIT
.rw-r--r--  879 saulecabrera  3 Apr 11:12 README.md
drwxr-xr-x    - saulecabrera  3 Apr 11:12 src
```

While the failing dependencies have the following permissions:

```
.rw-r--r--  835 saulecabrera  3 Apr 11:12 Cargo.toml
.rw-r-----  11k saulecabrera  3 Apr 11:12 LICENSE-APACHE
.rw-r----- 1.1k saulecabrera  3 Apr 11:12 LICENSE-MIT
.rw-r----- 1.1k saulecabrera  3 Apr 11:12 README.md
drwxr-xr-x    - saulecabrera  3 Apr 11:12 src
drwxr-xr-x    - saulecabrera  3 Apr 11:12 tests
```