### PR TITLE
Default to Ruby 3.2 in all workflows

### DIFF
--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
           cargo-cache: true
           cargo-vendor: true
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        ruby: ["3.1"]
+        ruby: ["3.2"]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
 
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           rustup-toolchain: "nightly"
           bundler-cache: true
           cargo-cache: true

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -11,6 +11,7 @@ on:
         type: choice
         options:
           - "head"
+          - "3.2"
           - "3.1"
           - "3.0"
           - "2.7"
@@ -31,7 +32,7 @@ jobs:
 
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
-          ruby-version: ${{ inputs.ruby-version || '3.1' }}
+          ruby-version: ${{ inputs.ruby-version || '3.2' }}
           bundler-cache: true
           cargo-cache: true
           cache-version: v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: false
           cargo-cache: true
           cargo-vendor: true
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
           cargo-cache: true
           cache-version: v1


### PR DESCRIPTION
I realized that all workflows were using Ruby 3.1 when reviewing #158. Bumping all workflows to use 3.2 given that's the latest.