### PR TITLE
Drop support for Ruby 2.7

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -14,7 +14,6 @@ on:
           - "3.2"
           - "3.1"
           - "3.0"
-          - "2.7"
   push:
     branches: ["*"]
     tags-ignore: ["v*"] # Skip Memcheck for releases

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,6 +1,6 @@
 # For available configuration options, see:
 #   https://github.com/testdouble/standard
-ruby_version: 2.6
+ruby_version: 3.0
 ignore:
   - 'vendor/**/*'
   - 'pkg/**/*'

--- a/wasmtime.gemspec
+++ b/wasmtime.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "A Ruby binding for Wasmtime, a WebAssembly runtime."
   spec.homepage = "https://github.com/BytecodeAlliance/wasmtime-rb"
   spec.license = "Apache-2.0"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = "https://github.com/BytecodeAlliance/wasmtime-rb"
   spec.metadata["source_code_uri"] = "https://github.com/BytecodeAlliance/wasmtime-rb"


### PR DESCRIPTION
Ruby 2.7 is now EOL and no longer officially supported by Ruby. For that reason, the GitHub action we're using no longer includes 2.7 in its matrix by default. Instead of adding it back, I'm removing support for 2.7 entirely. Given we're a pretty new and niche gem, I don't foresee this being a problem.

---

I'd like to merge this before we re-trigger the v7.0.0 release so that I can include this in the changelog, otherwise there won't be a note of 2.7 being dropped for pre-compiled extensions.