### PR TITLE
Remove warning from Ractor spec

### DIFF
--- a/spec/integration/ractor_spec.rb
+++ b/spec/integration/ractor_spec.rb
@@ -1,50 +1,48 @@
-if RUBY_VERSION.start_with?("3.")
-  RSpec.describe "Ractor" do
-    let(:wat) { <<~WAT }
-      (module
-        (func $module/hello (result i32 i64 f32 f64)
-          i32.const 1
-          i64.const 2
-          f32.const 3.0
-          f64.const 4.0
-        )
-
-        (export "hello" (func $module/hello))
+RSpec.describe "Ractor", ractor: true do
+  let(:wat) { <<~WAT }
+    (module
+      (func $module/hello (result i32 i64 f32 f64)
+        i32.const 1
+        i64.const 2
+        f32.const 3.0
+        f64.const 4.0
       )
-    WAT
 
-    it "supports running inside Ractors" do
-      r = Ractor.new(wat) do |wat|
-        engine = Wasmtime::Engine.new
-        mod = Wasmtime::Module.new(engine, wat)
+      (export "hello" (func $module/hello))
+    )
+  WAT
+
+  it "supports running inside Ractors" do
+    r = Ractor.new(wat) do |wat|
+      engine = Wasmtime::Engine.new
+      mod = Wasmtime::Module.new(engine, wat)
+      store_data = Object.new
+      store = Wasmtime::Store.new(engine, store_data)
+      Wasmtime::Instance.new(store, mod).invoke("hello")
+    end
+
+    result = r.take
+    expect(result).to eq([1, 2, 3.0, 4.0])
+  end
+
+  it "supports sharing Engine & Module with Ractors" do
+    engine = Wasmtime::Engine.new
+    mod = Wasmtime::Module.new(engine, wat)
+
+    Ractor.make_shareable(engine)
+    Ractor.make_shareable(mod)
+
+    ractors = []
+    3.times do
+      ractors << Ractor.new(engine, mod) do |engine, mod|
         store_data = Object.new
         store = Wasmtime::Store.new(engine, store_data)
         Wasmtime::Instance.new(store, mod).invoke("hello")
       end
-
-      result = r.take
-      expect(result).to eq([1, 2, 3.0, 4.0])
     end
 
-    it "supports sharing Engine & Module with Ractors" do
-      engine = Wasmtime::Engine.new
-      mod = Wasmtime::Module.new(engine, wat)
-
-      Ractor.make_shareable(engine)
-      Ractor.make_shareable(mod)
-
-      ractors = []
-      3.times do
-        ractors << Ractor.new(engine, mod) do |engine, mod|
-          store_data = Object.new
-          store = Wasmtime::Store.new(engine, store_data)
-          Wasmtime::Instance.new(store, mod).invoke("hello")
-        end
-      end
-
-      ractors.each do |ractor|
-        expect(ractor.take).to eq([1, 2, 3.0, 4.0])
-      end
+    ractors.each do |ractor|
+      expect(ractor.take).to eq([1, 2, 3.0, 4.0])
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,6 +91,14 @@ RSpec.configure do |config|
       with_gc_stress { ex.run }
     end
   end
+
+  config.around(:each, :ractor) do |example|
+    was = Warning[:experimental]
+    Warning[:experimental] = false
+    example.run
+  ensure
+    Warning[:experimental] = was
+  end
 end
 
 at_exit { GC.start(full_mark: true) } if ENV["GC_AT_EXIT"] == "1"


### PR DESCRIPTION
Ractors are experimental, thus Ruby warns when using them. We don't need to be reminded every time we run the tests though, so let's silence the experimental warning when running those tests.

Also remove the check for Ruby version since all versions we support now have Ractors.