### PR TITLE
Test that funcrefs aren't used across stores

### DIFF
--- a/spec/unit/func_spec.rb
+++ b/spec/unit/func_spec.rb
@@ -107,6 +107,22 @@ module Wasmtime
         func.call(1)
         expect(called).to be true
       end
+
+      it "disallows cross-store funcref arg" do
+        store2 = Store.new(engine, {})
+        func = Func.new(store, [:funcref], []) {}
+        store2_func = Func.new(store2, [], []) {}
+
+        expect { func.call(store2_func) }.to raise_error(Wasmtime::Error, /cross-`Store`/)
+      end
+
+      it "disallows cross-store funcref result" do
+        store2 = Store.new(engine, {})
+        store2_func = Func.new(store2, [], []) {}
+        func = Func.new(store, [], [:funcref]) { |_, funcref| store2_func }
+
+        expect { func.call }.to raise_error(Wasmtime::Error, /cross-`Store`/)
+      end
     end
 
     describe "Caller" do


### PR DESCRIPTION
I tried speeding up func calls by using `Func::call_unchecked` (9a0ab36d344a68beefa3093aebb5a9583b3a72ca), thinking it was fine because we ensure the Func's args and results type invariants when converting Ruby types to Wasm values. Except there's (at least) one invariant that we didn't uphold: that values aren't shared across stores.

This PR adds 2 tests to ensure we always handle the cross-store access for Func.