### PR TITLE
Add support for using Winch as a compiler strategy

### DIFF
--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -13,6 +13,7 @@ embed = ["magnus/embed"]
 tokio = ["dep:tokio", "dep:async-timer"]
 all-arch = ["wasmtime/all-arch"]
 ruby-api = []
+winch = ["wasmtime/winch"]
 
 [dependencies]
 lazy_static = "1.4.0"
@@ -20,7 +21,7 @@ magnus = { version = "0.5.5", features = ["rb-sys-interop"] }
 rb-sys = { version = "*", default-features = false, features = [
   "stable-api-compiled-fallback",
 ] }
-wasmtime = { version = "= 14.0.1", features = ["winch"] }
+wasmtime = { version = "= 14.0.1" }
 wasmtime-wasi = "= 14.0.1"
 wasi-common = "= 14.0.1"
 wasi-cap-std-sync = "= 14.0.1"

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -20,7 +20,7 @@ magnus = { version = "0.5.5", features = ["rb-sys-interop"] }
 rb-sys = { version = "*", default-features = false, features = [
   "stable-api-compiled-fallback",
 ] }
-wasmtime = { version = "= 14.0.1" }
+wasmtime = { version = "= 14.0.1", features = ["winch"] }
 wasmtime-wasi = "= 14.0.1"
 wasi-common = "= 14.0.1"
 wasi-cap-std-sync = "= 14.0.1"

--- a/ext/src/ruby_api/config.rs
+++ b/ext/src/ruby_api/config.rs
@@ -107,7 +107,7 @@ pub fn hash_to_config(hash: RHash) -> Result<Config, Error> {
             config.profiler(entry.try_into()?);
         } else if *CRANELIFT_OPT_LEVEL == id {
             config.cranelift_opt_level(entry.try_into()?);
-        } else if *STRATEGY == id {
+        } else if *STRATEGY == id && cfg!(feature = "winch") {
             config.strategy(entry.try_into()?);
         } else if *TARGET == id {
             let target: Option<String> = entry.try_into()?;

--- a/ext/src/ruby_api/config.rs
+++ b/ext/src/ruby_api/config.rs
@@ -11,7 +11,7 @@ use std::{
     convert::{TryFrom, TryInto},
     sync::Arc,
 };
-use wasmtime::{Config, OptLevel, ProfilingStrategy, WasmBacktraceDetails};
+use wasmtime::{Config, OptLevel, ProfilingStrategy, Strategy, WasmBacktraceDetails};
 
 define_rb_intern!(
     DEBUG_INFO => "debug_info",
@@ -25,6 +25,7 @@ define_rb_intern!(
     WASM_MEMORY64 => "wasm_memory64",
     PROFILER => "profiler",
     CRANELIFT_OPT_LEVEL => "cranelift_opt_level",
+    STRATEGY => "strategy",
     PARALLEL_COMPILATION => "parallel_compilation",
     NONE => "none",
     JITDUMP => "jitdump",
@@ -32,6 +33,9 @@ define_rb_intern!(
     SPEED => "speed",
     SPEED_AND_SIZE => "speed_and_size",
     TARGET => "target",
+    AUTO => "auto",
+    CRANELIFT => "cranelift",
+    WINCH => "winch",
 );
 
 lazy_static! {
@@ -52,6 +56,15 @@ lazy_static! {
         ];
 
         SymbolEnum::new(":profiler", mapping)
+    };
+    static ref STRATEGY_MAPPING: SymbolEnum<'static, Strategy> = {
+        let mapping = vec![
+            (*AUTO, Strategy::Auto),
+            (*CRANELIFT, Strategy::Cranelift),
+            (*WINCH, Strategy::Winch),
+        ];
+
+        SymbolEnum::new(":strategy", mapping)
     };
 }
 
@@ -94,6 +107,8 @@ pub fn hash_to_config(hash: RHash) -> Result<Config, Error> {
             config.profiler(entry.try_into()?);
         } else if *CRANELIFT_OPT_LEVEL == id {
             config.cranelift_opt_level(entry.try_into()?);
+        } else if *STRATEGY == id {
+            config.strategy(entry.try_into()?);
         } else if *TARGET == id {
             let target: Option<String> = entry.try_into()?;
 
@@ -176,5 +191,12 @@ impl TryFrom<ConfigEntry> for wasmtime::OptLevel {
     type Error = magnus::Error;
     fn try_from(value: ConfigEntry) -> Result<Self, Error> {
         OPT_LEVEL_MAPPING.get(value.1)
+    }
+}
+
+impl TryFrom<ConfigEntry> for wasmtime::Strategy {
+    type Error = magnus::Error;
+    fn try_from(value: ConfigEntry) -> Result<Self, Error> {
+        STRATEGY_MAPPING.get(value.1)
     }
 }

--- a/ext/src/ruby_api/engine.rs
+++ b/ext/src/ruby_api/engine.rs
@@ -79,7 +79,7 @@ impl Engine {
     /// @option config [Boolean] :parallel_compilation (true) Whether compile WASM using multiple threads
     /// @option config [Symbol] :cranelift_opt_level One of +none+, +speed+, +speed_and_size+.
     /// @option config [Symbol] :profiler One of +none+, +jitdump+, +vtune+.
-    /// @option config [Symbol] :strategy One of +auto+, +cranelift+, +winch+
+    /// @option config [Symbol] :strategy One of +auto+, +cranelift+, +winch+ (requires crate feature `winch` to be enabled)
     /// @option config [String] :target
     ///
     /// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Engine.html

--- a/ext/src/ruby_api/engine.rs
+++ b/ext/src/ruby_api/engine.rs
@@ -79,6 +79,7 @@ impl Engine {
     /// @option config [Boolean] :parallel_compilation (true) Whether compile WASM using multiple threads
     /// @option config [Symbol] :cranelift_opt_level One of +none+, +speed+, +speed_and_size+.
     /// @option config [Symbol] :profiler One of +none+, +jitdump+, +vtune+.
+    /// @option config [Symbol] :strategy One of +auto+, +cranelift+, +winch+
     /// @option config [String] :target
     ///
     /// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Engine.html

--- a/spec/unit/engine_spec.rb
+++ b/spec/unit/engine_spec.rb
@@ -41,7 +41,8 @@ module Wasmtime
       # enum options represented as symbols
       [
         [:cranelift_opt_level, [:none, :speed, :speed_and_size]],
-        [:profiler, profiler_options]
+        [:profiler, profiler_options],
+        [:strategy, [:auto, :cranelift, :winch]]
       ].each do |option, valid|
         it "supports #{option}" do
           valid.each { |value| Engine.new(option => value) }

--- a/spec/unit/engine_spec.rb
+++ b/spec/unit/engine_spec.rb
@@ -42,7 +42,6 @@ module Wasmtime
       [
         [:cranelift_opt_level, [:none, :speed, :speed_and_size]],
         [:profiler, profiler_options],
-        [:strategy, [:auto, :cranelift, :winch]]
       ].each do |option, valid|
         it "supports #{option}" do
           valid.each { |value| Engine.new(option => value) }

--- a/spec/unit/engine_spec.rb
+++ b/spec/unit/engine_spec.rb
@@ -41,7 +41,7 @@ module Wasmtime
       # enum options represented as symbols
       [
         [:cranelift_opt_level, [:none, :speed, :speed_and_size]],
-        [:profiler, profiler_options],
+        [:profiler, profiler_options]
       ].each do |option, valid|
         it "supports #{option}" do
           valid.each { |value| Engine.new(option => value) }


### PR DESCRIPTION
Adds support for setting the `strategy` config option in Wasmtime. Also enables the Winch feature in Wasmtime so the `winch` strategy can be used.