### PR TITLE
Allow perfmap as a profiling config

### DIFF
--- a/ext/src/ruby_api/config.rs
+++ b/ext/src/ruby_api/config.rs
@@ -30,6 +30,7 @@ define_rb_intern!(
     NONE => "none",
     JITDUMP => "jitdump",
     VTUNE => "vtune",
+    PERFMAP => "perfmap",
     SPEED => "speed",
     SPEED_AND_SIZE => "speed_and_size",
     TARGET => "target",
@@ -54,6 +55,7 @@ lazy_static! {
             (*NONE, ProfilingStrategy::None),
             (*JITDUMP, ProfilingStrategy::JitDump),
             (*VTUNE, ProfilingStrategy::VTune),
+            (*PERFMAP, ProfilingStrategy::PerfMap)
         ];
 
         SymbolEnum::new(":profiler", mapping)

--- a/ext/src/ruby_api/config.rs
+++ b/ext/src/ruby_api/config.rs
@@ -55,7 +55,7 @@ lazy_static! {
             (*NONE, ProfilingStrategy::None),
             (*JITDUMP, ProfilingStrategy::JitDump),
             (*VTUNE, ProfilingStrategy::VTune),
-            (*PERFMAP, ProfilingStrategy::PerfMap)
+            (*PERFMAP, ProfilingStrategy::PerfMap),
         ];
 
         SymbolEnum::new(":profiler", mapping)


### PR DESCRIPTION
# why? 

perfmap is an allowed value as a profiling strategy (and it's also the most cross platform, it works on mac too if you use samply!)

# how?

just add the symbol and add it to the mapping