### PR TITLE
Adding a String in-memory storage option to `WasiCtxBuilder` stdout/err 

### DIFF
--- a/spec/unit/wasi_spec.rb
+++ b/spec/unit/wasi_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "json"
+require "tmpdir"
 
 module Wasmtime
   RSpec.describe "WASI" do
@@ -51,6 +52,13 @@ module Wasmtime
         expect(stdout.fetch("name")).to eq("stdout")
         expect(stderr.fetch("name")).to eq("stderr")
         expect(stdout.dig("wasi", "stdin")).to eq("stdin content")
+      end
+
+      it "writes std streams to string" do
+        str = ""
+        wasi_config = WasiCtxBuilder.new.set_stdout_string(str)
+        run_wasi_module(wasi_config)
+        expect(str.size > 1).to eq(true)
       end
 
       it "reads stdin from string" do

--- a/spec/unit/wasi_spec.rb
+++ b/spec/unit/wasi_spec.rb
@@ -58,7 +58,9 @@ module Wasmtime
         str = ""
         wasi_config = WasiCtxBuilder.new.set_stdout_string(str)
         run_wasi_module(wasi_config)
-        expect(str.size > 1).to eq(true)
+
+        parsed_output = JSON.parse(str)
+        expect(parsed_output.fetch("name")).to eq("stdout")
       end
 
       it "reads stdin from string" do


### PR DESCRIPTION
In our project, we are implementing wasmtime-rb to execute user code performantly and safely. This code must execute quickly, as this is just one step in a potentially many-step process. While reviewing the WasiCtxBuilder options, we found that ReadStream offered both an on-disk (File) and in-memory (String) options while WriteStream only had an on-disk (File) option. This PR will implement a String option for WriteStream to ensure we have the most performant option.

Adding String to WriteStream introduces the potential for memory usage errors. This PR will also provide configurable memory size capacity. **Not yet implemented**

Remaining Tasks/Issues

- [ ]  Mutable Warning: `The variable does not need to be mutable.`
- [ ] Performance Benchmark
- [ ] Limit size
- [ ] Performance Benchmark
