### PR TITLE
Ruby 3.3 update

### DIFF
--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
           cargo-cache: true
           cargo-vendor: true
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        ruby: ["3.2"]
+        ruby: ["3.3"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           rustup-toolchain: "${{ env.NIGHTLY_VERSION }}"
           bundler-cache: true
           cargo-cache: true

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -7,10 +7,11 @@ on:
       ruby-version:
         description: "Ruby version to memcheck"
         required: true
-        default: "3.2"
+        default: "3.3"
         type: choice
         options:
           - "head"
+          - "3.3"
           - "3.2"
           - "3.1"
           - "3.0"
@@ -36,7 +37,7 @@ jobs:
 
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
-          ruby-version: ${{ inputs.ruby-version || '3.2' }}
+          ruby-version: ${{ inputs.ruby-version || '3.3' }}
           bundler-cache: true
           cargo-cache: true
           cache-version: v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: false
           cargo-cache: true
           cargo-vendor: true
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
           cargo-cache: true
           cache-version: v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,18 +1134,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.83"
+version = "0.9.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5b8d560b60790a3e60e56e73a8c7be88ac14e6af39fc82b5eca72c71753840"
+checksum = "7285f2a7b92f58ab198e3fd59a71d2861478f9c4642f41e83582385818941697"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.83"
+version = "0.9.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d2bfd00002007d7e9ad93d0397437933040caf452d260c26dbef5fd95ae1a6"
+checksum = "71583945f94dabb6c0dfa63f1b71e929c1901e1e288ef3739ab8bed3b7069550"
 dependencies = [
  "bindgen",
  "lazy_static",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
     rake (13.1.0)
     rake-compiler (1.2.5)
       rake
-    rb_sys (0.9.83)
+    rb_sys (0.9.86)
     regexp_parser (2.8.2)
     rexml (3.2.6)
     rspec (3.12.0)


### PR DESCRIPTION
- Use Ruby 3.3 in all GitHub workflows
- Update rb-sys to be able to build 3.3 stable binaries