### PR TITLE
Fix gemspec for 3.3 compat

### DIFF
--- a/wasmtime.gemspec
+++ b/wasmtime.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
   spec.license = "Apache-2.0"
   spec.required_ruby_version = ">= 3.0.0"
 
-  spec.metadata["homepage_uri"] = "https://github.com/BytecodeAlliance/wasmtime-rb"
   spec.metadata["source_code_uri"] = "https://github.com/BytecodeAlliance/wasmtime-rb"
   spec.metadata["cargo_crate_name"] = "wasmtime-rb"
   spec.metadata["changelog_uri"] = "https://github.com/bytecodealliance/wasmtime-rb/blob/main/CHANGELOG.md"


### PR DESCRIPTION
RubyGems now emits a warning on duplicated values. Given we set strict mode, warnings raise. That's causing `rake pkg:ruby:test` to crash.

This fixes the issue by dropping the `"homepage_uri"` metadata key, which is redundant with the homepage field on the gemspec.