### PR TITLE
Fix occasional Func call params conversion error

### DIFF
--- a/ext/src/ruby_api/func.rs
+++ b/ext/src/ruby_api/func.rs
@@ -235,7 +235,7 @@ pub fn make_func_closure(
 
         let callable = callable.0;
 
-        match (callable.call(unsafe { rparams.as_slice() }), results.len()) {
+        match (callable.call(rparams), results.len()) {
             (Ok(_proc_result), 0) => {
                 wrapped_caller.get().expire();
                 Ok(())


### PR DESCRIPTION
In #205 I was getting some occasional test failures in the tests covering converting types for func args. The error was that `false` couldn't be converted into the desired type. The was unusual, as nowhere was passing `false`.

It appears there was an edge case where the Ruby Garbage collector could kick in at just the wrong time and collect the array backing the slice just before the objects were copied to a new array. I think this would lead to the slice containing `null`/`0`, which ends up as `false` when treated as a Ruby value.

I suspect for this edge case to occur a particular compiler optimisation needed to kick in, as when it was occurring it was consistent, but with slightly different conditions (say different Ruby version or different platform) it never happened.

`rb_proc_call` (the Ruby api behind `Proc::call`) takes its arguments as a Ruby array, so the slice was being converted to an array anyway, so we can just drop the `as_slice` to fix things.
