### PR TITLE
Bump magnus to 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "magnus"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e9585bfe236e88e6b10b6d8eb5349bd0e0009f3f9dff8d2e99a82601b33743"
+checksum = "4778544796676e8428e9c622460ebf284bea52d8b10db3aeb449d8b5e61b3a13"
 dependencies = [
  "magnus-macros",
  "rb-sys",


### PR DESCRIPTION
This brings back rb-sys' `stable-api` feature.

See [magnus' changelog](https://github.com/matsadler/magnus/blob/main/CHANGELOG.md#062---2023-09-18).