### PR TITLE
Unlock the GVL when compiling WASM code

### DIFF
--- a/ext/src/helpers/mod.rs
+++ b/ext/src/helpers/mod.rs
@@ -1,6 +1,11 @@
 mod macros;
+mod nogvl;
 mod static_id;
 mod symbol_enum;
+mod tmplock;
 
+// pub use nogvl::without_gvl;
+pub use nogvl::nogvl;
 pub use static_id::StaticId;
 pub use symbol_enum::SymbolEnum;
+pub use tmplock::Tmplock;

--- a/ext/src/helpers/mod.rs
+++ b/ext/src/helpers/mod.rs
@@ -4,7 +4,6 @@ mod static_id;
 mod symbol_enum;
 mod tmplock;
 
-// pub use nogvl::without_gvl;
 pub use nogvl::nogvl;
 pub use static_id::StaticId;
 pub use symbol_enum::SymbolEnum;

--- a/ext/src/helpers/nogvl.rs
+++ b/ext/src/helpers/nogvl.rs
@@ -1,0 +1,29 @@
+use std::{ffi::c_void, mem::MaybeUninit, ptr::null_mut};
+
+use rb_sys::rb_thread_call_without_gvl;
+
+unsafe extern "C" fn call_without_gvl<F, R>(arg: *mut c_void) -> *mut c_void
+where
+    F: FnMut() -> R,
+    R: Sized,
+{
+    let arg = arg as *mut (&mut F, &mut MaybeUninit<R>);
+    let (func, result) = unsafe { &mut *arg };
+    result.write(func());
+
+    null_mut()
+}
+
+pub fn nogvl<F, R>(mut func: F) -> R
+where
+    F: FnMut() -> R,
+    R: Sized,
+{
+    let result = MaybeUninit::uninit();
+    let arg_ptr = &(&mut func, &result) as *const _ as *mut c_void;
+
+    unsafe {
+        rb_thread_call_without_gvl(Some(call_without_gvl::<F, R>), arg_ptr, None, null_mut());
+        result.assume_init()
+    }
+}

--- a/ext/src/helpers/tmplock.rs
+++ b/ext/src/helpers/tmplock.rs
@@ -1,0 +1,45 @@
+use magnus::{
+    rb_sys::{protect, AsRawValue},
+    RString,
+};
+
+pub trait Tmplock {
+    unsafe fn as_locked_slice(&self) -> Result<(&[u8], TmplockGuard), magnus::Error>;
+    unsafe fn as_locked_str(&self) -> Result<(&str, TmplockGuard), magnus::Error>;
+}
+
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct TmplockGuard {
+    raw: rb_sys::VALUE,
+}
+
+impl Drop for TmplockGuard {
+    fn drop(&mut self) {
+        let result = unsafe { protect(|| rb_sys::rb_str_unlocktmp(self.raw)) };
+        debug_assert!(
+            result.is_ok(),
+            "failed to unlock tmplock for unknown reason"
+        );
+    }
+}
+
+impl Tmplock for RString {
+    unsafe fn as_locked_slice(&self) -> Result<(&[u8], TmplockGuard), magnus::Error> {
+        let raw = self.as_raw();
+        let slice = self.as_slice();
+        let raw = protect(|| rb_sys::rb_str_locktmp(raw))?;
+        let guard = TmplockGuard { raw };
+
+        Ok((slice, guard))
+    }
+
+    unsafe fn as_locked_str(&self) -> Result<(&str, TmplockGuard), magnus::Error> {
+        let str_result = self.as_str()?;
+        let raw = self.as_raw();
+        let raw = protect(|| rb_sys::rb_str_locktmp(raw))?;
+        let guard = TmplockGuard { raw };
+
+        Ok((str_result, guard))
+    }
+}

--- a/ext/src/ruby_api/engine.rs
+++ b/ext/src/ruby_api/engine.rs
@@ -171,7 +171,7 @@ impl Engine {
     /// @return [String] Binary String of the compiled module.
     /// @see Module.deserialize
     pub fn precompile_module(&self, wat_or_wasm: RString) -> Result<RString, Error> {
-        let (wat_or_wasm, _guard) = unsafe { wat_or_wasm.as_locked_slice() }?;
+        let (wat_or_wasm, _guard) = wat_or_wasm.as_locked_slice()?;
 
         nogvl(|| self.inner.precompile_module(wat_or_wasm))
             .map(|bytes| RString::from_slice(&bytes))

--- a/ext/src/ruby_api/module.rs
+++ b/ext/src/ruby_api/module.rs
@@ -36,7 +36,7 @@ impl Module {
     /// @return [Wasmtime::Module]
     pub fn new(engine: &Engine, wat_or_wasm: RString) -> Result<Self, Error> {
         let eng = engine.get();
-        let (locked_slice, _locked_slice_guard) = unsafe { wat_or_wasm.as_locked_slice() }?;
+        let (locked_slice, _locked_slice_guard) = wat_or_wasm.as_locked_slice()?;
         let module = nogvl(|| ModuleImpl::new(eng, locked_slice))
             .map_err(|e| error!("Could not build module: {}", e))?;
 
@@ -50,7 +50,7 @@ impl Module {
     /// @return [Wasmtime::Module]
     pub fn from_file(engine: &Engine, path: RString) -> Result<Self, Error> {
         let eng = engine.get();
-        let (path, _locked_str_guard) = unsafe { path.as_locked_str()? };
+        let (path, _locked_str_guard) = path.as_locked_str()?;
         // SAFETY: this string is immediately copied and never moved off the stack
         let module = nogvl(|| ModuleImpl::from_file(eng, path))
             .map_err(|e| error!("Could not build module from file: {}", e))?;
@@ -96,7 +96,7 @@ impl Module {
     /// @see .deserialize
     pub fn serialize(&self) -> Result<RString, Error> {
         let module = self.get();
-        let bytes = nogvl(|| module.serialize());
+        let bytes = module.serialize();
 
         bytes
             .map(|bytes| RString::from_slice(&bytes))

--- a/ext/src/ruby_api/module.rs
+++ b/ext/src/ruby_api/module.rs
@@ -1,7 +1,18 @@
+use std::{
+    mem::{transmute, MaybeUninit},
+    ops::Deref,
+    os::raw::c_void,
+};
+
 use super::{engine::Engine, root};
-use crate::error;
-use magnus::{class, function, method, Error, Module as _, Object, RString};
-use rb_sys::tracking_allocator::ManuallyTracked;
+use crate::{
+    error,
+    helpers::{nogvl, Tmplock},
+};
+use magnus::{class, function, method, rb_sys::AsRawValue, Error, Module as _, Object, RString};
+use rb_sys::{
+    rb_str_locktmp, rb_str_unlocktmp, tracking_allocator::ManuallyTracked, RSTRING_LEN, RSTRING_PTR,
+};
 use wasmtime::Module as ModuleImpl;
 
 /// @yard
@@ -25,8 +36,8 @@ impl Module {
     /// @return [Wasmtime::Module]
     pub fn new(engine: &Engine, wat_or_wasm: RString) -> Result<Self, Error> {
         let eng = engine.get();
-        // SAFETY: this string is immediately copied and never moved off the stack
-        let module = ModuleImpl::new(eng, unsafe { wat_or_wasm.as_slice() })
+        let (locked_slice, _locked_slice_guard) = unsafe { wat_or_wasm.as_locked_slice() }?;
+        let module = nogvl(|| ModuleImpl::new(eng, locked_slice))
             .map_err(|e| error!("Could not build module: {}", e))?;
 
         Ok(module.into())
@@ -39,8 +50,9 @@ impl Module {
     /// @return [Wasmtime::Module]
     pub fn from_file(engine: &Engine, path: RString) -> Result<Self, Error> {
         let eng = engine.get();
+        let (path, _locked_str_guard) = unsafe { path.as_locked_str()? };
         // SAFETY: this string is immediately copied and never moved off the stack
-        let module = ModuleImpl::from_file(eng, unsafe { path.as_str()? })
+        let module = nogvl(|| ModuleImpl::from_file(eng, path))
             .map_err(|e| error!("Could not build module from file: {}", e))?;
 
         Ok(module.into())
@@ -83,8 +95,10 @@ impl Module {
     /// @return [String]
     /// @see .deserialize
     pub fn serialize(&self) -> Result<RString, Error> {
-        self.get()
-            .serialize()
+        let module = self.get();
+        let bytes = nogvl(|| module.serialize());
+
+        bytes
             .map(|bytes| RString::from_slice(&bytes))
             .map_err(|e| error!("{:?}", e))
     }


### PR DESCRIPTION
Compiling code is CPU intensive, and can often take a significant amount of time (100ms+). Currently, we hold the GVL while compiling which means that no other Ruby threads can execute while compiling WASM. This makes gem a non-starter for multi-threaded apps (like Puma web apps).

### What this PR does

This PR makes it so we unlock the GVL in the following methods:

- `Wasmtime::Module.new`
- `Wasmtime::Module.from_file`
- `Wasmtime::Engine#precompile_file`