### PR TITLE
Add support for resource limits on `Wasmtime::Store`

### DIFF
--- a/ext/src/ruby_api/store.rs
+++ b/ext/src/ruby_api/store.rs
@@ -1,15 +1,14 @@
 use super::errors::wasi_exit_error;
 use super::{caller::Caller, engine::Engine, root, trap::Trap, wasi_ctx_builder::WasiCtxBuilder};
 use crate::{define_rb_intern, error};
-use magnus::method::MethodCAry;
-use magnus::{Class, RHash};
+use magnus::Class;
 use magnus::{
     class, function,
     gc::{Compactor, Marker},
     method, scan_args,
     typed_data::Obj,
     value::Opaque,
-    DataTypeFunctions, Error, IntoValue, Module, Object, Ruby, TypedData, Value, StaticSymbol
+    DataTypeFunctions, Error, IntoValue, Module, Object, Ruby, TypedData, Value,
 };
 use std::cell::UnsafeCell;
 use std::convert::TryFrom;
@@ -136,7 +135,7 @@ impl Store {
             wasi,
             refs: Default::default(),
             last_error: Default::default(),
-            store_limits: Default::default() // StoreLimits::default()
+            store_limits: Default::default()
         };
         let store = Self {
             inner: UnsafeCell::new(StoreImpl::new(eng, store_data)),
@@ -173,9 +172,20 @@ impl Store {
         Ok(())
     }
 
+    /// @yard
+    /// Sets limits on the {Store}.
+    /// @param memory_size [Integer]
+    ///   The maximum number of bytes a linear memory can grow to.
+    /// @param table_elements [Integer]
+    ///   The maximum number of elements in a table.
+    /// @param instances [Integer]
+    ///   The maximum number of instances that can be created for a Store.
+    /// @param tables [Integer]
+    ///   The maximum number of tables that can be created for a Store.
+    /// @param memories [Integer]
+    ///   The maximum number of linear memories that can be created for a Store.
+    /// @raise [Error] if arguments can not be converted.
     pub fn set_limits(&self, args: &[Value]) -> Result<(), Error> {
-        let mut limiter: StoreLimitsBuilder = StoreLimitsBuilder::new();
-
         let args = scan_args::scan_args::<(), (), (), (), _, ()>(args)?;
         let kw = scan_args::get_kwargs::<
             _,
@@ -188,6 +198,7 @@ impl Store {
             &["memory_size", "table_elements", "instances", "tables", "memories"]
         )?;
 
+        let mut limiter: StoreLimitsBuilder = StoreLimitsBuilder::new();
         let (memory_size, table_elements, instances, tables, memories) = kw.optional;
 
         if memory_size.is_some() {

--- a/spec/unit/store_spec.rb
+++ b/spec/unit/store_spec.rb
@@ -25,14 +25,92 @@ module Wasmtime
         GC.compact
         expect(store.data.value).to eql({foo: "bar", baz: "qux"})
       end
+    end
 
-      it "sets a limit" do
+    describe "#set_limits" do
+      it "sets a memory size limit" do
         store = Store.new(engine)
         store.set_limits(memory_size: 150_000)
 
         mem = Memory.new(store, min_size: 1)
         mem.grow(1)
         expect { mem.grow(1) }.to raise_error(Wasmtime::Error, "failed to grow memory by `1`")
+      end
+
+      it "sets a table elements limit" do
+        store = Store.new(engine)
+        store.set_limits(table_elements: 1)
+
+        table = Table.new(store, :funcref, nil, min_size: 1)
+        expect { table.grow(1, nil) }.to raise_error(Wasmtime::Error, "failed to grow table by `1`")
+      end
+
+      it "sets a instances limit" do
+        store = Store.new(engine)
+        store.set_limits(instances: 1)
+
+        mod = Module.new(engine, <<~WAT)
+          (module
+            (func nop)
+            (start 0))
+        WAT
+
+        Instance.new(store, mod)
+        expect { Instance.new(store, mod) }.to raise_error(Wasmtime::Error, "resource limit exceeded: instance count too high at 2")
+      end
+
+      it "sets a tables limit" do
+        store = Store.new(engine)
+        store.set_limits(tables: 1)
+
+        mod = Module.new(engine, <<~WAT)
+          (module
+            (table $table1 1 funcref)
+            (table $table2 1 funcref)
+            (func nop)
+            (start 0))
+        WAT
+
+        expect { Instance.new(store, mod) }.to raise_error(Wasmtime::Error, "resource limit exceeded: table count too high at 2")
+      end
+
+      it "sets a memories limit" do
+        store = Store.new(engine)
+        store.set_limits(memories: 1)
+
+        mod = Module.new(engine, <<~WAT)
+          (module
+            (memory $memory1 1)
+            (memory $memory2 1)
+            (func nop)
+            (start 0))
+        WAT
+
+        expect { Instance.new(store, mod) }.to raise_error(Wasmtime::Error, "resource limit exceeded: memory count too high at 2")
+      end
+
+      it "handles multiple keywords" do
+        store = Store.new(engine)
+        store.set_limits(memories: 1, tables: 1)
+
+        memory_mod = Module.new(engine, <<~WAT)
+          (module
+            (memory $memory1 1)
+            (memory $memory2 1)
+            (func nop)
+            (start 0))
+        WAT
+
+        table_mod = Module.new(engine, <<~WAT)
+          (module
+            (table $table1 1 funcref)
+            (table $table2 1 funcref)
+            (func nop)
+            (start 0))
+        WAT
+
+        expect { Instance.new(store, memory_mod) }.to raise_error(Wasmtime::Error, "resource limit exceeded: memory count too high at 2")
+        expect { Instance.new(store, table_mod) }.to raise_error(Wasmtime::Error, "resource limit exceeded: table count too high at 2")
       end
     end
   end

--- a/spec/unit/store_spec.rb
+++ b/spec/unit/store_spec.rb
@@ -25,12 +25,9 @@ module Wasmtime
         GC.compact
         expect(store.data.value).to eql({foo: "bar", baz: "qux"})
       end
-    end
 
-    describe "#set_limits" do
       it "sets a memory size limit" do
-        store = Store.new(engine)
-        store.set_limits(memory_size: 150_000)
+        store = Store.new(engine, memory_size: 150_000)
 
         mem = Memory.new(store, min_size: 1)
         mem.grow(1)
@@ -38,16 +35,14 @@ module Wasmtime
       end
 
       it "sets a table elements limit" do
-        store = Store.new(engine)
-        store.set_limits(table_elements: 1)
+        store = Store.new(engine, table_elements: 1)
 
         table = Table.new(store, :funcref, nil, min_size: 1)
         expect { table.grow(1, nil) }.to raise_error(Wasmtime::Error, "failed to grow table by `1`")
       end
 
       it "sets a instances limit" do
-        store = Store.new(engine)
-        store.set_limits(instances: 1)
+        store = Store.new(engine, instances: 1)
 
         mod = Module.new(engine, <<~WAT)
           (module
@@ -60,8 +55,7 @@ module Wasmtime
       end
 
       it "sets a tables limit" do
-        store = Store.new(engine)
-        store.set_limits(tables: 1)
+        store = Store.new(engine, tables: 1)
 
         mod = Module.new(engine, <<~WAT)
           (module
@@ -75,8 +69,7 @@ module Wasmtime
       end
 
       it "sets a memories limit" do
-        store = Store.new(engine)
-        store.set_limits(memories: 1)
+        store = Store.new(engine, memories: 1)
 
         mod = Module.new(engine, <<~WAT)
           (module
@@ -90,8 +83,7 @@ module Wasmtime
       end
 
       it "handles multiple keywords" do
-        store = Store.new(engine)
-        store.set_limits(memories: 1, tables: 1)
+        store = Store.new(engine, memories: 1, tables: 1)
 
         memory_mod = Module.new(engine, <<~WAT)
           (module

--- a/spec/unit/store_spec.rb
+++ b/spec/unit/store_spec.rb
@@ -25,6 +25,15 @@ module Wasmtime
         GC.compact
         expect(store.data.value).to eql({foo: "bar", baz: "qux"})
       end
+
+      it "sets a limit" do
+        store = Store.new(engine)
+        store.set_limits(memory_size: 150_000)
+
+        mem = Memory.new(store, min_size: 1)
+        mem.grow(1)
+        expect { mem.grow(1) }.to raise_error(Wasmtime::Error, "failed to grow memory by `1`")
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds support to set limits in the constructor of a `Wasmtime::Store` using a `StoreLimitsBuilder`. 

Example usage:
```ruby
store = Store.new(engine, limits: {memories: 1, tables: 1})
```
