### PR TITLE
Allow for manually disposing of `Wasmtime::Module`

### DIFF
--- a/ext/src/ruby_api/errors.rs
+++ b/ext/src/ruby_api/errors.rs
@@ -23,6 +23,21 @@ pub fn conversion_error() -> ExceptionClass {
     ruby.get_inner(&ERR)
 }
 
+/// Raised when attempting to use a module that has been disposed.
+pub fn module_disposed_error() -> ExceptionClass {
+    static ERR: Lazy<ExceptionClass> =
+        Lazy::new(|_| root().const_get("ModuleDisposedError").unwrap());
+    let ruby = Ruby::get().unwrap();
+    ruby.get_inner(&ERR)
+}
+
+pub fn module_disposed_err<T>() -> Result<T, Error> {
+    Err(Error::new(
+        module_disposed_error(),
+        "module has been disposed",
+    ))
+}
+
 /// Raised when a WASI program terminates early by calling +exit+.
 pub fn wasi_exit_error() -> ExceptionClass {
     static ERR: Lazy<ExceptionClass> = Lazy::new(|_| root().const_get("WasiExit").unwrap());

--- a/lib/wasmtime/error.rb
+++ b/lib/wasmtime/error.rb
@@ -45,4 +45,7 @@ module Wasmtime
       "WASI exit with code #{code}"
     end
   end
+
+  # Raised when attempting to use a disposed Wasmtime module.
+  class ModuleDisposedError < Error; end
 end

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -86,5 +86,22 @@ module Wasmtime
         expect(mod).to be_a(Wasmtime::Module)
       end
     end
+
+    describe "#dispose" do
+      it "renders the module unusable" do
+        mod = Module.new(engine, wat)
+        mod.dispose!
+        expect { mod.serialize }.to raise_error(Wasmtime::Error)
+      end
+
+      it "can be called multiple times" do
+        mod = Module.new(engine, wat)
+
+        expect(mod.disposed?).to be(false)
+        expect(mod.dispose!).to be(true)
+        expect(mod.disposed?).to be(true)
+        expect(mod.dispose!).to be(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
Sometimes, you'd rather not wait on the GC to drop the module....

