### PR TITLE
chore: Bump download artifact in publish doc workflow

### DIFF
--- a/.github/actions/publish-doc/action.yml
+++ b/.github/actions/publish-doc/action.yml
@@ -7,7 +7,7 @@ runs:
         ref: gh-pages
 
     - name: Download docs
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: doc
         path: doc


### PR DESCRIPTION
This is probably why the doc related workflows are failing. 