### PR TITLE
chore: Disable Ruby head in CI temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ jobs:
     steps:
       - id: fetch
         uses: oxidize-rb/actions/fetch-ci-data@v1
+        with:
+          # TODO(#286)
+          # Disabaling head until we reach consensus on what to do in the
+          # presence of errors.
+          stable-ruby-versions: |
+            exclude: [head]
 
   ci:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The failure in main is preventing a release of v17 of the gem, so until we reach consensus about what to do with `head`, I think it's reasonable to exclude head for CI.

ref: https://github.com/bytecodealliance/wasmtime-rb/issues/286 