### PR TITLE
[ci skip] chore: Update release workflow to use download-artifact@v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,11 @@ jobs:
           cargo-cache: true
           cache-version: v1
 
-      - uses: actions/download-artifact@v4
+      # It seems that v4 is not compatible with how artifacts are uploaded by
+      # oxidize-rb/cross-gem-action. So this must stay as v3 until the issue
+      # below is fixed.
+      # See https://github.com/oxidize-rb/actions/issues/27, for more details.
+      - uses: actions/download-artifact@v3
         with:
           name: cross-gem
 


### PR DESCRIPTION
It seems that the release workflow is failing to find the uploaded `cross-gem` because the version that uploaded it is different than the one that is trying to download it. I'll try putting the previous version back to see if this fixes the release issues that I'm seeing. 