### PR TITLE
add string buffer for stdout and stderr

### DIFF
--- a/ext/src/helpers/mod.rs
+++ b/ext/src/helpers/mod.rs
@@ -1,10 +1,12 @@
 mod macros;
 mod nogvl;
+mod output_limited_buffer;
 mod static_id;
 mod symbol_enum;
 mod tmplock;
 
 pub use nogvl::nogvl;
+pub use output_limited_buffer::OutputLimitedBuffer;
 pub use static_id::StaticId;
 pub use symbol_enum::SymbolEnum;
 pub use tmplock::Tmplock;

--- a/ext/src/helpers/output_limited_buffer.rs
+++ b/ext/src/helpers/output_limited_buffer.rs
@@ -26,10 +26,14 @@ impl io::Write for OutputLimitedBuffer {
         let mut inner_buffer = self.buffer.get_inner_with(&ruby);
 
         if buf.is_empty() {
-            return Ok(buf.len());
+            return Ok(0);
         }
 
-        if inner_buffer.len().checked_add(buf.len()).is_some_and(|val| val < self.capacity){
+        if inner_buffer
+            .len()
+            .checked_add(buf.len())
+            .is_some_and(|val| val < self.capacity)
+        {
             let amount_written = inner_buffer.write(buf)?;
             if amount_written < buf.len() {
                 return Ok(amount_written);

--- a/ext/src/helpers/output_limited_buffer.rs
+++ b/ext/src/helpers/output_limited_buffer.rs
@@ -32,10 +32,10 @@ impl io::Write for OutputLimitedBuffer {
         let is_frozen = inner_buffer.as_value().is_frozen();
 
         if is_frozen {
-            return (Err(io::Error::new(
+            return Err(io::Error::new(
                 ErrorKind::WriteZero,
                 "Cannot write to a frozen buffer.",
-            )));
+            ));
             // return Ok(buf.len());
         }
 

--- a/ext/src/helpers/output_limited_buffer.rs
+++ b/ext/src/helpers/output_limited_buffer.rs
@@ -29,14 +29,13 @@ impl io::Write for OutputLimitedBuffer {
 
         let mut inner_buffer = self.buffer.get_inner_with(&ruby);
 
+        // Handling frozen case here is necessary because magnus does not check if a string is frozen before writing to it.
         let is_frozen = inner_buffer.as_value().is_frozen();
-
         if is_frozen {
             return Err(io::Error::new(
                 ErrorKind::WriteZero,
                 "Cannot write to a frozen buffer.",
             ));
-            // return Ok(buf.len());
         }
 
         if buf.is_empty() {

--- a/ext/src/helpers/output_limited_buffer.rs
+++ b/ext/src/helpers/output_limited_buffer.rs
@@ -1,0 +1,44 @@
+use magnus::{value::InnerValue, value::Opaque, RString, Ruby};
+use std::io;
+
+pub struct OutputLimitedBuffer {
+    buffer: Opaque<RString>,
+    /// The maximum number of bytes that can be written to the output stream buffer.
+    capacity: usize,
+}
+
+impl OutputLimitedBuffer {
+    #[must_use]
+    pub fn new(buffer: Opaque<RString>, capacity: usize) -> Self {
+        Self { buffer, capacity }
+    }
+}
+
+impl io::Write for OutputLimitedBuffer {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        /// Append a buffer to the string and truncate when hitting the capacity.
+        /// We return the input buffer size regardless of whether we truncated or not to avoid a panic.
+        let ruby = Ruby::get().unwrap();
+
+        let mut inner_buffer = self.buffer.get_inner_with(&ruby);
+
+        if buf.is_empty() {
+            return Ok(buf.len());
+        }
+
+        if inner_buffer.len() + buf.len() > self.capacity {
+            let portion = self.capacity - inner_buffer.len();
+            inner_buffer.write(&buf[0..portion])?
+        } else {
+            inner_buffer.write(buf)?
+        };
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let ruby = Ruby::get().unwrap();
+
+        self.buffer.get_inner_with(&ruby).flush()
+    }
+}

--- a/ext/src/helpers/output_limited_buffer.rs
+++ b/ext/src/helpers/output_limited_buffer.rs
@@ -3,6 +3,7 @@ use magnus::{
     RString, Ruby,
 };
 use std::io;
+use std::io::ErrorKind;
 
 /// A buffer that limits the number of bytes that can be written to it.
 /// If the buffer is full, it will truncate the data.
@@ -31,7 +32,11 @@ impl io::Write for OutputLimitedBuffer {
         let is_frozen = inner_buffer.as_value().is_frozen();
 
         if is_frozen {
-            return Ok(0);
+            return (Err(io::Error::new(
+                ErrorKind::WriteZero,
+                "Cannot write to a frozen buffer.",
+            )));
+            // return Ok(buf.len());
         }
 
         if buf.is_empty() {

--- a/ext/src/helpers/output_limited_buffer.rs
+++ b/ext/src/helpers/output_limited_buffer.rs
@@ -1,4 +1,7 @@
-use magnus::{value::InnerValue, value::Opaque, RString, Ruby};
+use magnus::{
+    value::{InnerValue, Opaque, ReprValue},
+    RString, Ruby,
+};
 use std::io;
 
 /// A buffer that limits the number of bytes that can be written to it.
@@ -24,6 +27,12 @@ impl io::Write for OutputLimitedBuffer {
         let ruby = Ruby::get().unwrap();
 
         let mut inner_buffer = self.buffer.get_inner_with(&ruby);
+
+        let is_frozen = inner_buffer.as_value().is_frozen();
+
+        if is_frozen {
+            return Ok(0);
+        }
 
         if buf.is_empty() {
             return Ok(0);

--- a/ext/src/ruby_api/store.rs
+++ b/ext/src/ruby_api/store.rs
@@ -300,12 +300,6 @@ impl<'a> StoreContextValue<'a> {
         } else if let Some(exit) = error.downcast_ref::<I32Exit>() {
             wasi_exit_error().new_instance((exit.0,)).unwrap().into()
         } else {
-            if let Some(error) = error.downcast_ref::<std::io::Error>() {
-                if error.kind() == std::io::ErrorKind::WriteZero {
-                    return error!("{}", error.to_string());
-                }
-            }
-
             Trap::try_from(error)
                 .map(|trap| trap.into())
                 .unwrap_or_else(|e| error!("{}", e))

--- a/ext/src/ruby_api/store.rs
+++ b/ext/src/ruby_api/store.rs
@@ -300,6 +300,12 @@ impl<'a> StoreContextValue<'a> {
         } else if let Some(exit) = error.downcast_ref::<I32Exit>() {
             wasi_exit_error().new_instance((exit.0,)).unwrap().into()
         } else {
+            if let Some(error) = error.downcast_ref::<std::io::Error>() {
+                if error.kind() == std::io::ErrorKind::WriteZero {
+                    return error!("{}", error.to_string());
+                }
+            }
+
             Trap::try_from(error)
                 .map(|trap| trap.into())
                 .unwrap_or_else(|e| error!("{}", e))

--- a/ext/src/ruby_api/wasi_ctx.rs
+++ b/ext/src/ruby_api/wasi_ctx.rs
@@ -78,6 +78,8 @@ impl WasiCtx {
 
     /// @yard
     /// Set stdout to write to a string buffer.
+    /// If the string buffer is frozen, Wasm execution will raise a Wasmtime::Error error.
+    /// No encoding checks are done on the resulting string, it is the caller's responsibility to ensure the string contains a valid encoding
     /// @param buffer [String] The string buffer to write to.
     /// @param capacity [Integer] The maximum number of bytes that can be written to the output buffer.
     /// @def set_stout_buffer(buffer, capacity)
@@ -104,6 +106,8 @@ impl WasiCtx {
 
     /// @yard
     /// Set stderr to write to a string buffer.
+    /// If the string buffer is frozen, Wasm execution will raise a Wasmtime::Error error.
+    /// No encoding checks are done on the resulting string, it is the caller's responsibility to ensure the string contains a valid encoding
     /// @param buffer [String] The string buffer to write to.
     /// @param capacity [Integer] The maximum number of bytes that can be written to the output buffer.
     /// @def set_stout_buffer(buffer, capacity)

--- a/ext/src/ruby_api/wasi_ctx_builder.rs
+++ b/ext/src/ruby_api/wasi_ctx_builder.rs
@@ -1,12 +1,13 @@
 use super::{root, WasiCtx};
 use crate::error;
+use crate::helpers::OutputLimitedBuffer;
 use magnus::{
     class, function, gc::Marker, method, typed_data::Obj, value::Opaque, DataTypeFunctions, Error,
     Module, Object, RArray, RHash, RString, Ruby, TryConvert, TypedData,
 };
 use std::cell::RefCell;
 use std::{fs::File, path::PathBuf};
-use wasi_common::pipe::ReadPipe;
+use wasi_common::pipe::{ReadPipe, WritePipe};
 
 enum ReadStream {
     Inherit,
@@ -27,12 +28,14 @@ impl ReadStream {
 enum WriteStream {
     Inherit,
     Path(Opaque<RString>),
+    Buffer(Opaque<RString>, usize),
 }
 impl WriteStream {
     pub fn mark(&self, marker: &Marker) {
         match self {
             Self::Inherit => (),
             Self::Path(v) => marker.mark(*v),
+            Self::Buffer(v, _) => marker.mark(*v),
         }
     }
 }
@@ -150,6 +153,17 @@ impl WasiCtxBuilder {
     }
 
     /// @yard
+    /// Set stdout to write to a string buffer.
+    /// @param buffer [String] The string buffer to write to.
+    /// @param capacity [Integer] The maximum number of bytes that can be written to the output buffer.
+    /// @def set_stdout_buffer(buffer, capacity)
+    /// @return [WasiCtxBuilder] +self+
+    pub fn set_stdout_buffer(rb_self: RbSelf, buffer: RString, capacity: usize) -> RbSelf {
+        let mut inner = rb_self.inner.borrow_mut();
+        inner.stdout = Some(WriteStream::Buffer(buffer.into(), capacity));
+        rb_self
+    }
+    /// @yard
     /// Inherit stderr from the current Ruby process.
     /// @return [WasiCtxBuilder] +self+
     pub fn inherit_stderr(rb_self: RbSelf) -> RbSelf {
@@ -170,6 +184,17 @@ impl WasiCtxBuilder {
         rb_self
     }
 
+    /// @yard
+    /// Set stderr to write to a string buffer.
+    /// @param buffer [String] The string buffer to write to.
+    /// @param capacity [Integer] The maximum number of bytes that can be written to the output buffer.
+    /// @def set_stderr_buffer(buffer, capacity)
+    /// @return [WasiCtxBuilder] +self+
+    pub fn set_stderr_buffer(rb_self: RbSelf, buffer: RString, capacity: usize) -> RbSelf {
+        let mut inner = rb_self.inner.borrow_mut();
+        inner.stderr = Some(WriteStream::Buffer(buffer.into(), capacity));
+        rb_self
+    }
     /// @yard
     /// Set env to the specified +Hash+.
     /// @param env [Hash<String, String>]
@@ -216,6 +241,10 @@ impl WasiCtxBuilder {
                 WriteStream::Path(path) => {
                     builder.stdout(file_w(ruby.get_inner(*path)).map(wasi_file)?)
                 }
+                WriteStream::Buffer(buffer, capacity) => {
+                    let buf = OutputLimitedBuffer::new(*buffer, *capacity);
+                    builder.stdout(Box::new(WritePipe::new(buf)))
+                }
             };
         }
 
@@ -224,6 +253,10 @@ impl WasiCtxBuilder {
                 WriteStream::Inherit => builder.inherit_stderr(),
                 WriteStream::Path(path) => {
                     builder.stderr(file_w(ruby.get_inner(*path)).map(wasi_file)?)
+                }
+                WriteStream::Buffer(buffer, capacity) => {
+                    let buf = OutputLimitedBuffer::new(*buffer, *capacity);
+                    builder.stderr(Box::new(WritePipe::new(buf)))
                 }
             };
         }
@@ -282,11 +315,19 @@ pub fn init() -> Result<(), Error> {
         "set_stdout_file",
         method!(WasiCtxBuilder::set_stdout_file, 1),
     )?;
+    class.define_method(
+        "set_stdout_buffer",
+        method!(WasiCtxBuilder::set_stdout_buffer, 2),
+    )?;
 
     class.define_method("inherit_stderr", method!(WasiCtxBuilder::inherit_stderr, 0))?;
     class.define_method(
         "set_stderr_file",
         method!(WasiCtxBuilder::set_stderr_file, 1),
+    )?;
+    class.define_method(
+        "set_stderr_buffer",
+        method!(WasiCtxBuilder::set_stderr_buffer, 2),
     )?;
 
     class.define_method("set_env", method!(WasiCtxBuilder::set_env, 1))?;

--- a/ext/src/ruby_api/wasi_ctx_builder.rs
+++ b/ext/src/ruby_api/wasi_ctx_builder.rs
@@ -154,6 +154,8 @@ impl WasiCtxBuilder {
 
     /// @yard
     /// Set stdout to write to a string buffer.
+    /// If the string buffer is frozen, Wasm execution will raise a Wasmtime::Error error.
+    /// No encoding checks are done on the resulting string, it is the caller's responsibility to ensure the string contains a valid encoding
     /// @param buffer [String] The string buffer to write to.
     /// @param capacity [Integer] The maximum number of bytes that can be written to the output buffer.
     /// @def set_stdout_buffer(buffer, capacity)
@@ -187,6 +189,8 @@ impl WasiCtxBuilder {
 
     /// @yard
     /// Set stderr to write to a string buffer.
+    /// If the string buffer is frozen, Wasm execution will raise a Wasmtime::Error error.
+    /// No encoding checks are done on the resulting string, it is the caller's responsibility to ensure the string contains a valid encoding
     /// @param buffer [String] The string buffer to write to.
     /// @param capacity [Integer] The maximum number of bytes that can be written to the output buffer.
     /// @def set_stderr_buffer(buffer, capacity)

--- a/ext/src/ruby_api/wasi_ctx_builder.rs
+++ b/ext/src/ruby_api/wasi_ctx_builder.rs
@@ -163,6 +163,7 @@ impl WasiCtxBuilder {
         inner.stdout = Some(WriteStream::Buffer(buffer.into(), capacity));
         rb_self
     }
+
     /// @yard
     /// Inherit stderr from the current Ruby process.
     /// @return [WasiCtxBuilder] +self+

--- a/spec/unit/wasi_spec.rb
+++ b/spec/unit/wasi_spec.rb
@@ -103,7 +103,10 @@ module Wasmtime
           .build
 
         stdout_str.freeze
-        run_wasi_module(wasi_config)
+        expect { run_wasi_module(wasi_config) }.to raise_error do |error|
+          expect(error).to be_a(Wasmtime::Error)
+          expect(error.message).to match(/Cannot write to a frozen buffer./)
+        end
 
         parsed_stderr = JSON.parse(stderr_str)
         expect(stdout_str).to eq("")
@@ -121,11 +124,13 @@ module Wasmtime
           .build
 
         stderr_str.freeze
-        run_wasi_module(wasi_config)
+        expect { run_wasi_module(wasi_config) }.to raise_error do |error|
+          expect(error).to be_a(Wasmtime::Error)
+          expect(error.message).to match(/Cannot write to a frozen buffer./)
+        end
 
-        parsed_stdout = JSON.parse(stdout_str)
         expect(stderr_str).to eq("")
-        expect(parsed_stdout.fetch("name")).to eq("stdout")
+        expect(stdout_str).to eq("")
       end
 
       it "reads stdin from string" do

--- a/spec/unit/wasi_spec.rb
+++ b/spec/unit/wasi_spec.rb
@@ -55,6 +55,42 @@ module Wasmtime
         expect(stdout.dig("wasi", "stdin")).to eq("stdin content")
       end
 
+      it "writes std streams to buffers" do
+        File.write(tempfile_path("stdin"), "stdin content")
+
+        stdout_str = ""
+        stderr_str = ""
+        wasi_config = WasiCtxBuilder.new
+          .set_stdin_file(tempfile_path("stdin"))
+          .set_stdout_buffer(stdout_str, 40000)
+          .set_stderr_buffer(stderr_str, 40000)
+          .build
+
+        run_wasi_module(wasi_config)
+
+        parsed_stdout = JSON.parse(stdout_str)
+        parsed_stderr = JSON.parse(stderr_str)
+        expect(parsed_stdout.fetch("name")).to eq("stdout")
+        expect(parsed_stderr.fetch("name")).to eq("stderr")
+      end
+
+      it "writes std streams to buffers until capacity" do
+        File.write(tempfile_path("stdin"), "stdin content")
+
+        stdout_str = ""
+        stderr_str = ""
+        wasi_config = WasiCtxBuilder.new
+          .set_stdin_file(tempfile_path("stdin"))
+          .set_stdout_buffer(stdout_str, 5)
+          .set_stderr_buffer(stderr_str, 10)
+          .build
+
+        run_wasi_module(wasi_config)
+
+        expect(stdout_str).to eq("{\"nam")
+        expect(stderr_str).to eq("{\"name\":\"s")
+      end
+
       it "reads stdin from string" do
         env = wasi_module_env { |config| config.set_stdin_string("¡UTF-8 from Ruby!") }
         expect(env.fetch("stdin")).to eq("¡UTF-8 from Ruby!")

--- a/spec/unit/wasi_spec.rb
+++ b/spec/unit/wasi_spec.rb
@@ -105,7 +105,7 @@ module Wasmtime
         stdout_str.freeze
         expect { run_wasi_module(wasi_config) }.to raise_error do |error|
           expect(error).to be_a(Wasmtime::Error)
-          expect(error.message).to eq("Cannot write to a frozen buffer.")
+          expect(error.message).to match(/error while executing at wasm backtrace:/)
         end
 
         parsed_stderr = JSON.parse(stderr_str)
@@ -126,7 +126,7 @@ module Wasmtime
         stderr_str.freeze
         expect { run_wasi_module(wasi_config) }.to raise_error do |error|
           expect(error).to be_a(Wasmtime::Error)
-          expect(error.message).to eq("Cannot write to a frozen buffer.")
+          expect(error.message).to match(/error while executing at wasm backtrace:/)
         end
 
         expect(stderr_str).to eq("")

--- a/spec/unit/wasi_spec.rb
+++ b/spec/unit/wasi_spec.rb
@@ -105,7 +105,7 @@ module Wasmtime
         stdout_str.freeze
         expect { run_wasi_module(wasi_config) }.to raise_error do |error|
           expect(error).to be_a(Wasmtime::Error)
-          expect(error.message).to match(/Cannot write to a frozen buffer./)
+          expect(error.message).to eq("Cannot write to a frozen buffer.")
         end
 
         parsed_stderr = JSON.parse(stderr_str)
@@ -126,7 +126,7 @@ module Wasmtime
         stderr_str.freeze
         expect { run_wasi_module(wasi_config) }.to raise_error do |error|
           expect(error).to be_a(Wasmtime::Error)
-          expect(error.message).to match(/Cannot write to a frozen buffer./)
+          expect(error.message).to eq("Cannot write to a frozen buffer.")
         end
 
         expect(stderr_str).to eq("")


### PR DESCRIPTION
This PR adds support for using a string with a byte limit as the stdout and stderr for `WasiCtx` and `WasiCtxBuilder`. 

## Usage:
```rust
stdout_str = ""
stderr_str = ""
WasiCtxBuilder.new
          .inherit_stdin()
          .set_stdout_buffer(stdout_str, 50000)
          .set_stderr_buffer(stderr_str, 50000)
          .build
```