### PR TITLE
Fix CI

### DIFF
--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0"
 publish = false
 build = "build.rs"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ruby_gte_3_0)'] }
+
 [features]
 default = ["tokio", "all-arch"]
 embed = ["magnus/embed"]

--- a/ext/src/lib.rs
+++ b/ext/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::doc_lazy_continuation)]
 use magnus::{Error, Ruby};
 mod helpers;
 mod ruby_api;


### PR DESCRIPTION
The update to the version of Clippy in Rust 1.80 resulted in new warnings being flagged. This marks `ruby_gte_3_0` as an expected `cfg` gate and allows `doc_lazy_continuation` in the `ruby-ext` module since we use Yard which follows a slightly different convention.