### PR TITLE
Add support to enable/disable wasm reference types

### DIFF
--- a/ext/src/ruby_api/config.rs
+++ b/ext/src/ruby_api/config.rs
@@ -45,6 +45,7 @@ define_rb_intern!(
     ALLOCATION_STRATEGY => "allocation_strategy",
     POOLING => "pooling",
     ON_DEMAND => "on_demand",
+    WASM_REFERENCE_TYPES => "wasm_reference_types",
 );
 
 lazy_static! {
@@ -104,6 +105,8 @@ pub fn hash_to_config(hash: RHash) -> Result<Config, Error> {
             config.wasm_memory64(entry.try_into()?);
         } else if *PARALLEL_COMPILATION == id {
             config.parallel_compilation(entry.try_into()?);
+        } else if *WASM_REFERENCE_TYPES == id {
+            config.wasm_reference_types(entry.try_into()?);
         } else if *PROFILER == id {
             config.profiler(entry.try_into()?);
         } else if *CRANELIFT_OPT_LEVEL == id {

--- a/ext/src/ruby_api/engine.rs
+++ b/ext/src/ruby_api/engine.rs
@@ -76,6 +76,7 @@ impl Engine {
     /// @option config [Boolean] :wasm_threads
     /// @option config [Boolean] :wasm_multi_memory
     /// @option config [Boolean] :wasm_memory64
+    /// @option config [Boolean] :wasm_reference_types
     /// @option config [Boolean] :parallel_compilation (true) Whether compile WASM using multiple threads
     /// @option config [Boolean] :generate_address_map Configures whether compiled artifacts will contain information to map native program addresses back to the original wasm module. This configuration option is `true` by default. Disabling this feature can result in considerably smaller serialized modules.
     /// @option config [Symbol] :cranelift_opt_level One of +none+, +speed+, +speed_and_size+.

--- a/spec/unit/engine_spec.rb
+++ b/spec/unit/engine_spec.rb
@@ -27,7 +27,8 @@ module Wasmtime
         [:wasm_threads, true],
         [:wasm_multi_memory, true],
         [:wasm_memory64, true],
-        [:parallel_compilation, true]
+        [:parallel_compilation, true],
+        [:wasm_reference_types, true]
       ].each do |option, valid, invalid = nil|
         it "supports #{option}" do
           Engine.new(option => valid)


### PR DESCRIPTION
Add support to enable/disable wasm reference types on engine config.