### PR TITLE
Fix YARD documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,3 +128,6 @@ jobs:
           omitNameDuringUpdate: true
           omitPrereleaseDuringUpdate: true
           skipIfReleaseExists: true
+
+      - name: Publish doc
+        uses: ./.github/actions/publish-doc

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development do
   gem "standard", "~> 1.40"
   gem "get_process_mem"
   gem "yard", require: false
-  gem "yard-rustdoc", "~> 0.3.2", require: false
+  gem "yard-rustdoc", "~> 0.4.0", require: false
   gem "benchmark-ips", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,10 @@ GEM
     bigdecimal (3.1.8)
     diff-lcs (1.5.1)
     ffi (1.17.0)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x64-mingw-ucrt)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     get_process_mem (1.0.0)
       bigdecimal (>= 2.0)
       ffi (~> 1.0)
@@ -79,7 +83,7 @@ GEM
       prettier_print (>= 1.2.0)
     unicode-display_width (2.5.0)
     yard (0.9.36)
-    yard-rustdoc (0.3.2)
+    yard-rustdoc (0.4.0)
       syntax_tree (~> 5.0)
       yard (~> 0.9)
 
@@ -101,7 +105,7 @@ DEPENDENCIES
   standard (~> 1.40)
   wasmtime!
   yard
-  yard-rustdoc (~> 0.3.2)
+  yard-rustdoc (~> 0.4.0)
 
 BUNDLED WITH
    2.5.4

--- a/ext/src/ruby_api/pooling_allocation_config.rs
+++ b/ext/src/ruby_api/pooling_allocation_config.rs
@@ -39,7 +39,7 @@ impl PoolingAllocationConfig {
     }
 
     /// @yard
-    /// @def total_memories=
+    /// @def total_memories=(total_memories)
     /// @param total_memories [Integer]
     /// @return [Wasmtime::PoolingAllocationConfig]
     pub fn set_total_memories(rb_self: Obj<Self>, total_memories: u32) -> Result<Obj<Self>, Error> {
@@ -49,7 +49,7 @@ impl PoolingAllocationConfig {
     }
 
     /// @yard
-    /// @def total_tables=
+    /// @def total_tables=(total_tables)
     /// @param total_tables [Integer]
     /// @return [Wasmtime::PoolingAllocationConfig]
     pub fn set_total_tables(rb_self: Obj<Self>, total_tables: u32) -> Result<Obj<Self>, Error> {
@@ -58,7 +58,7 @@ impl PoolingAllocationConfig {
     }
 
     /// @yard
-    /// @def max_memories_per_module=
+    /// @def max_memories_per_module=(max_memories)
     /// @param max_memories [Integer]
     /// @return [Wasmtime::PoolingAllocationConfig]
     pub fn set_max_memories_per_module(
@@ -70,7 +70,7 @@ impl PoolingAllocationConfig {
     }
 
     /// @yard
-    /// @def max_tables_per_module=
+    /// @def max_tables_per_module=(max_tables)
     /// @param max_tables [Integer]
     /// @return [Wasmtime::PoolingAllocationConfig]
     pub fn set_max_tables_per_component(
@@ -82,14 +82,14 @@ impl PoolingAllocationConfig {
     }
 
     /// @yard
-    /// @def are_memory_protection_keys_available
+    /// @def memory_protection_keys_available?
     /// @return [Boolean]
     pub fn are_memory_protection_keys_available() -> Result<bool, Error> {
         Ok(wasmtime::PoolingAllocationConfig::are_memory_protection_keys_available())
     }
 
     /// @yard
-    /// @def async_stack_keep_resident=
+    /// @def async_stack_keep_resident=(amount)
     /// @param amount [Integer]
     /// @return [Wasmtime::PoolingAllocationConfig]
     pub fn set_async_stack_keep_resident(
@@ -100,7 +100,7 @@ impl PoolingAllocationConfig {
         Ok(rb_self)
     }
 
-    /// @def async_stack_zeroing=
+    /// @def async_stack_zeroing=(enable)
     /// @param enable [Boolean]
     /// @return [Wasmtime::PoolingAllocationConfig]
     pub fn set_async_stack_zeroing(rb_self: Obj<Self>, enable: Value) -> Result<Obj<Self>, Error> {

--- a/ext/src/ruby_api/store.rs
+++ b/ext/src/ruby_api/store.rs
@@ -107,7 +107,7 @@ unsafe impl Send for StoreData {}
 impl Store {
     /// @yard
     ///
-    /// @def new(engine, data = nil, wasi_ctx: nil)
+    /// @def new(engine, data = nil, wasi_ctx: nil, limits: nil)
     /// @param engine [Wasmtime::Engine]
     ///   The engine for this store.
     /// @param data [Object]
@@ -214,6 +214,7 @@ impl Store {
     }
 
     /// @yard
+    /// @def linear_memory_limit_hit?
     /// Returns whether the linear memory limit has been hit.
     ///
     /// @return [Boolean]

--- a/ext/src/ruby_api/wasi_ctx.rs
+++ b/ext/src/ruby_api/wasi_ctx.rs
@@ -40,8 +40,8 @@ impl WasiCtx {
 
     /// @yard
     /// Set stdin to read from the specified file.
-    /// @param path [String] The path of the file to read from.
     /// @def set_stdin_file(path)
+    /// @param path [String] The path of the file to read from.
     /// @return [WasiCtxBuilder] +self+
     fn set_stdin_file(rb_self: RbSelf, path: RString) -> RbSelf {
         let inner = rb_self.inner.borrow_mut();
@@ -52,8 +52,8 @@ impl WasiCtx {
 
     /// @yard
     /// Set stdin to the specified String.
-    /// @param content [String]
     /// @def set_stdin_string(content)
+    /// @param content [String]
     /// @return [WasiCtx] +self+
     fn set_stdin_string(rb_self: RbSelf, content: RString) -> RbSelf {
         let inner = rb_self.inner.borrow_mut();
@@ -66,8 +66,8 @@ impl WasiCtx {
     /// @yard
     /// Set stdout to write to a file. Will truncate the file if it exists,
     /// otherwise try to create it.
-    /// @param path [String] The path of the file to write to.
     /// @def set_stdout_file(path)
+    /// @param path [String] The path of the file to write to.
     /// @return [WasiCtx] +self+
     fn set_stdout_file(rb_self: RbSelf, path: RString) -> RbSelf {
         let inner = rb_self.inner.borrow_mut();
@@ -80,9 +80,9 @@ impl WasiCtx {
     /// Set stdout to write to a string buffer.
     /// If the string buffer is frozen, Wasm execution will raise a Wasmtime::Error error.
     /// No encoding checks are done on the resulting string, it is the caller's responsibility to ensure the string contains a valid encoding
+    /// @def set_stdout_buffer(buffer, capacity)
     /// @param buffer [String] The string buffer to write to.
     /// @param capacity [Integer] The maximum number of bytes that can be written to the output buffer.
-    /// @def set_stout_buffer(buffer, capacity)
     /// @return [WasiCtx] +self+
     fn set_stdout_buffer(rb_self: RbSelf, buffer: RString, capacity: usize) -> RbSelf {
         let inner = rb_self.inner.borrow_mut();
@@ -94,8 +94,8 @@ impl WasiCtx {
     /// @yard
     /// Set stderr to write to a file. Will truncate the file if it exists,
     /// otherwise try to create it.
-    /// @param path [String] The path of the file to write to.
     /// @def set_stderr_file(path)
+    /// @param path [String] The path of the file to write to.
     /// @return [WasiCtx] +self+
     fn set_stderr_file(rb_self: RbSelf, path: RString) -> RbSelf {
         let inner = rb_self.inner.borrow_mut();
@@ -108,9 +108,9 @@ impl WasiCtx {
     /// Set stderr to write to a string buffer.
     /// If the string buffer is frozen, Wasm execution will raise a Wasmtime::Error error.
     /// No encoding checks are done on the resulting string, it is the caller's responsibility to ensure the string contains a valid encoding
+    /// @def set_stderr_buffer(buffer, capacity)
     /// @param buffer [String] The string buffer to write to.
     /// @param capacity [Integer] The maximum number of bytes that can be written to the output buffer.
-    /// @def set_stout_buffer(buffer, capacity)
     /// @return [WasiCtx] +self+
     fn set_stderr_buffer(rb_self: RbSelf, buffer: RString, capacity: usize) -> RbSelf {
         let inner = rb_self.inner.borrow_mut();


### PR DESCRIPTION
YARD doc generation is broken in a few different ways, this change aims to fix all the known issues. Fixes #342.

Note: this won't retrigger doc generation for existing releases, but once this is merged I can manually build and push the docs for the current release.

**Issues:**

1. Docs for tagged releases (vx.y.z tags) was last generated for v6.0.0 because we stopped running CI in on versions in #120. This means that the current "latest" doc symlink points to v6.0.0, helping other doc issues go unnoticed (see next points).

   Fix: run the doc generation step on release as well.

2. YARD doc generation stopped working at some point last year when we updated the nightly version. The doc for main only has a handful of Ruby-defined APIs, but none of the Rust-defined APIs. The root cause is a change in rustdoc's JSON format which caused yard-rustdoc to miss all definitions.

   Fix: teach yard-rustdoc about the new format, and update the dependency. This will also fix an issue causing `Wasmtime::Memory::UnsafeSlice` to not show up in the class list sidebar. See: https://github.com/oxidize-rb/yard-rustdoc/compare/v0.3.2...v0.4.0

3. Documentation entries had issues (invalid names, missing args, etc.) This would normally be caught in CI, but they weren't given the docs for Rust-defined APIs were skipped (see above point).

-------


Before & after:
<img width="1179" alt="Screenshot 2024-09-19 at 11 51 13 AM" src="https://github.com/user-attachments/assets/032a7452-130d-4867-9262-6d8da42ebaeb">

