### PR TITLE
enable winch by default

### DIFF
--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -11,7 +11,7 @@ build = "build.rs"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ruby_gte_3_0)'] }
 
 [features]
-default = ["tokio", "all-arch"]
+default = ["tokio", "all-arch", "winch"]
 embed = ["magnus/embed"]
 tokio = ["dep:tokio", "dep:async-timer"]
 all-arch = ["wasmtime/all-arch"]

--- a/ext/src/ruby_api/engine.rs
+++ b/ext/src/ruby_api/engine.rs
@@ -81,7 +81,7 @@ impl Engine {
     /// @option config [Boolean] :generate_address_map Configures whether compiled artifacts will contain information to map native program addresses back to the original wasm module. This configuration option is `true` by default. Disabling this feature can result in considerably smaller serialized modules.
     /// @option config [Symbol] :cranelift_opt_level One of +none+, +speed+, +speed_and_size+.
     /// @option config [Symbol] :profiler One of +none+, +jitdump+, +vtune+.
-    /// @option config [Symbol] :strategy One of +auto+, +cranelift+, +winch+ (requires crate feature `winch` to be enabled)
+    /// @option config [Symbol] :strategy One of +auto+, +cranelift+, +winch+
     /// @option config [String] :target
     ///
     /// @see https://docs.rs/wasmtime/latest/wasmtime/struct.Engine.html

--- a/spec/unit/engine_spec.rb
+++ b/spec/unit/engine_spec.rb
@@ -41,6 +41,7 @@ module Wasmtime
 
       # enum options represented as symbols
       [
+        [:strategy, [:auto, :cranelift, :winch]],
         [:cranelift_opt_level, [:none, :speed, :speed_and_size]],
         [:profiler, profiler_options]
       ].each do |option, valid|


### PR DESCRIPTION
The `strategy` option isn't available in Ruby right now by default. Adding `winch` to the list of default features to enable using this option from Ruby.