### PR TITLE
docs: Update contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,17 +17,6 @@ Compile the gem, run the tests & Ruby linter:
 bundle exec rake
 ```
 
-## If running the Run Examples step of CI fails
-
-If there was an update to `deterministic-wasi-ctx`, try running:
-
-```
-$ cd examples/rust-crate
-$ cargo update -p deterministic-wasi-ctx
-```
-
-If the lock file for the example Rust crate changed, commit and push that change.
-
 ## Releasing
 
 1. Bump the `VERSION` in `lib/wasmtime/version.rb`


### PR DESCRIPTION
Removes instructions from the contributing docs regarding managing the `Cargo.lock` file for the Rust example

These instructions are no longer valid as of: https://github.com/bytecodealliance/wasmtime-rb/pull/389