### PR TITLE
Support component `enum`, `variant`, `flags` types

### DIFF
--- a/ext/src/ruby_api/component/convert.rs
+++ b/ext/src/ruby_api/component/convert.rs
@@ -5,7 +5,9 @@ use crate::{define_rb_intern, err, error, not_implemented};
 use magnus::exception::type_error;
 use magnus::rb_sys::AsRawValue;
 use magnus::value::{IntoId, Lazy, ReprValue};
-use magnus::{prelude::*, value, Error, IntoValue, RArray, RClass, RHash, RString, Ruby, Value};
+use magnus::{
+    prelude::*, try_convert, value, Error, IntoValue, RArray, RClass, RHash, RString, Ruby, Value,
+};
 use wasmtime::component::{Type, Val};
 
 define_rb_intern!(
@@ -89,7 +91,7 @@ pub(crate) fn component_val_to_rb(val: Val, _store: &StoreContextValue) -> Resul
             };
             result_class(&ruby).funcall(ruby_method, (ruby_argument,))
         }
-        Val::Flags(_vec) => not_implemented!("Flags not implemented"),
+        Val::Flags(vec) => Ok(vec.into_value()),
         Val::Resource(_resource_any) => not_implemented!("Resource not implemented"),
     }
 }
@@ -275,7 +277,7 @@ pub(crate) fn rb_to_component_val(
                 }
             }
         }
-        Type::Flags(_flags) => not_implemented!("Flags not implemented"),
+        Type::Flags(_) => Vec::<String>::try_convert(value).map(Val::Flags),
         Type::Own(_resource_type) => not_implemented!("Resource not implemented"),
         Type::Borrow(_resource_type) => not_implemented!("Resource not implemented"),
     }

--- a/ext/src/ruby_api/component/convert.rs
+++ b/ext/src/ruby_api/component/convert.rs
@@ -169,7 +169,10 @@ pub(crate) fn rb_to_component_val(
             Ok(Val::Tuple(vals))
         }
         Type::Variant(_variant) => not_implemented!("Variant not implemented"),
-        Type::Enum(_enum) => not_implemented!("Enum not implementend"),
+        Type::Enum(_) => {
+            let rstring = RString::try_convert(value)?;
+            rstring.to_string().map(Val::Enum)
+        }
         Type::Option(option_type) => {
             if value.is_nil() {
                 Ok(Val::Option(None))

--- a/lib/wasmtime/component.rb
+++ b/lib/wasmtime/component.rb
@@ -82,5 +82,51 @@ module Wasmtime
       # `.error` is used over `.new`.
       private :initialize
     end
+
+    # Represents a value for component model's variant case.
+    # A variant case has a name that uniquely identify the case within the
+    # variant and optionally a value.
+    #
+    # @example Constructing variants
+    #   # Given the following variant:
+    #   # variant filter {
+    #   #     all,
+    #   #     none,
+    #   #     lt(u32),
+    #   # }
+    #
+    #   Variant.new("all")
+    #   Variant.new("none")
+    #   Variant.new("lt", 100)
+    class Variant
+      # The name of the variant case
+      # @return [String]
+      attr_reader :name
+
+      # The optional payload of the variant case
+      # @return [Object]
+      attr_reader :value
+
+      # @param name [String] the name of variant case
+      # @param value [Object] the optional payload of the variant case
+      def initialize(name, value = nil)
+        @name = name
+        @value = value
+      end
+
+      def ==(other)
+        eql?(other)
+      end
+
+      def eql?(other)
+        self.class == other.class &&
+          name == other.name &&
+          value == other.value
+      end
+
+      def hash
+        [self.class, @name, @value].hash
+      end
+    end
   end
 end

--- a/spec/unit/component/convert_spec.rb
+++ b/spec/unit/component/convert_spec.rb
@@ -28,7 +28,7 @@ module Wasmtime
           ["list", [1, 2, 2**32 - 1]], # list<u32>
           ["record", {"x" => 1, "y" => 2}],
           ["tuple", [1, "foo"]], # tuple<u32, string>
-          # TODO variant
+          ["variant", Variant.new("all"), Variant.new("lt", 12)],
           ["enum", "l"],
           ["option", 0, nil], # option<u32>
           ["result", Result.ok(1), Result.error(2)], # result<u32, u32>
@@ -84,6 +84,8 @@ module Wasmtime
           ["record", {"x" => 1}, /struct field missing: y/],
           ["record", nil, /no implicit conversion of NilClass into Hash/],
           ["tuple", nil, /no implicit conversion of NilClass into Array/],
+          ["variant", Variant.new("no"), /invalid variant case "no", valid cases: \["all", "none", "lt"\]/],
+          ["variant", Variant.new("lt", "nah"), /(variant value for "lt")/],
           ["enum", "no", /enum variant name `no` is not valid/],
           ["result", nil, /undefined method `ok\?/],
           ["result-unit", Result.ok(""), /expected nil for result<_, E> ok branch/],

--- a/spec/unit/component/convert_spec.rb
+++ b/spec/unit/component/convert_spec.rb
@@ -29,7 +29,7 @@ module Wasmtime
           ["record", {"x" => 1, "y" => 2}],
           ["tuple", [1, "foo"]], # tuple<u32, string>
           # TODO variant
-          # TODO enum
+          ["enum", "l"],
           ["option", 0, nil], # option<u32>
           ["result", Result.ok(1), Result.error(2)], # result<u32, u32>
           ["result-unit", Result.ok(nil), Result.error(nil)]
@@ -84,6 +84,7 @@ module Wasmtime
           ["record", {"x" => 1}, /struct field missing: y/],
           ["record", nil, /no implicit conversion of NilClass into Hash/],
           ["tuple", nil, /no implicit conversion of NilClass into Array/],
+          ["enum", "no", /enum variant name `no` is not valid/],
           ["result", nil, /undefined method `ok\?/],
           ["result-unit", Result.ok(""), /expected nil for result<_, E> ok branch/],
           ["result-unit", Result.error(""), /expected nil for result<O, _> error branch/]

--- a/spec/unit/component/convert_spec.rb
+++ b/spec/unit/component/convert_spec.rb
@@ -32,8 +32,8 @@ module Wasmtime
           ["enum", "l"],
           ["option", 0, nil], # option<u32>
           ["result", Result.ok(1), Result.error(2)], # result<u32, u32>
-          ["result-unit", Result.ok(nil), Result.error(nil)]
-          # TODO flags
+          ["result-unit", Result.ok(nil), Result.error(nil)],
+          ["flags", [], ["read"], ["read", "write", "exec"]]
         ].each do |type, *values|
           values.each do |v|
             it "#{type} #{v.inspect}" do
@@ -89,7 +89,10 @@ module Wasmtime
           ["enum", "no", /enum variant name `no` is not valid/],
           ["result", nil, /undefined method `ok\?/],
           ["result-unit", Result.ok(""), /expected nil for result<_, E> ok branch/],
-          ["result-unit", Result.error(""), /expected nil for result<O, _> error branch/]
+          ["result-unit", Result.error(""), /expected nil for result<O, _> error branch/],
+          ["flags", ["no"], /unknown flag: `no`/],
+          ["flags", [1], /no implicit conversion of Integer into String/],
+          ["flags", 1, /no implicit conversion of Integer into Array/]
         ].each do |type, value, klass, msg|
           it "fails on #{type} #{value.inspect}" do
             expect { instance.invoke("id-#{type}", value) }.to raise_error(klass, msg)

--- a/spec/unit/component/variant_spec.rb
+++ b/spec/unit/component/variant_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+module Wasmtime
+  module Component
+    RSpec.describe Variant do
+      it "has name" do
+        expect(Variant.new("a", 1).name).to eq("a")
+      end
+
+      it "has value" do
+        expect(Variant.new("a", 1).value).to eq(1)
+      end
+
+      it "behaves like a value object" do
+        expect(Variant.new("a", 1)).to eq(Variant.new("a", 1))
+        expect(Variant.new("a", 1).hash).to eq(Variant.new("a", 1).hash)
+
+        expect(Variant.new("a")).not_to eq(Variant.new("b"))
+        expect(Variant.new("a", 1)).not_to eq(Variant.new("a", 2))
+        expect(Variant.new("a").hash).not_to eq(Variant.new("b").hash)
+        expect(Variant.new("a", 1).hash).not_to eq(Variant.new("a", 2).hash)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add support for `enum`, `variant` and `flags` component model types.

- `enum`: maps to a Ruby String. The string is not validated at convert time given Wasmtime will validate it at a later point. By adding an extra validation, we'd incur the validation cost twice. The tradeoff here is that the error happens outside of the conversion where we can no longer add additional context to the error message (e.g. list of valid values, which arg the error occurred in, etc.)
- `variant`: maps to a `Wasmtime::Component::Variant` similar to `result`.
- `flags`: maps to a Ruby Array of Strings, reflecting `Val::Flags` which wraps a `Vec<String>`.