### PR TITLE
Remove anyhow dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,7 +2035,6 @@ dependencies = [
 name = "wasmtime-rb"
 version = "9.0.4"
 dependencies = [
- "anyhow",
  "async-timer",
  "cap-std",
  "deterministic-wasi-ctx",

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -28,7 +28,6 @@ wasmtime = { version = "=26.0.0", features = ["memory-protection-keys"] }
 wasmtime-wasi = "=26.0.0"
 wasi-common = "=26.0.0"
 cap-std = "3.1.0"
-anyhow = "*" # Use whatever Wasmtime uses
 wat = "1.218.0"
 tokio = { version = "1.40.0", features = [
   "rt",

--- a/ext/src/ruby_api/func.rs
+++ b/ext/src/ruby_api/func.rs
@@ -243,7 +243,7 @@ macro_rules! caller_error {
     ($store:expr, $caller:expr, $error:expr) => {{
         $store.set_last_error($error);
         $caller.expire();
-        Err(anyhow::anyhow!(""))
+        Err(wasmtime::Error::msg(""))
     }};
 }
 
@@ -257,7 +257,7 @@ macro_rules! result_error {
 pub fn make_func_closure(
     ty: &wasmtime::FuncType,
     callable: Opaque<Proc>,
-) -> impl Fn(CallerImpl<'_, StoreData>, &[Val], &mut [Val]) -> anyhow::Result<()> + Send + Sync + 'static
+) -> impl Fn(CallerImpl<'_, StoreData>, &[Val], &mut [Val]) -> wasmtime::Result<()> + Send + Sync + 'static
 {
     let ty = ty.to_owned();
 
@@ -276,7 +276,7 @@ pub fn make_func_closure(
         for (i, param) in params.iter().enumerate() {
             let rparam = param
                 .to_ruby_value(&store_context)
-                .map_err(|e| anyhow::anyhow!(format!("invalid argument at index {i}: {e}")))?;
+                .map_err(|e| wasmtime::Error::msg(format!("invalid argument at index {i}: {e}")))?;
             rparams.push(rparam).unwrap();
         }
 

--- a/ext/src/ruby_api/store.rs
+++ b/ext/src/ruby_api/store.rs
@@ -317,7 +317,7 @@ impl<'a> StoreContextValue<'a> {
         };
     }
 
-    pub fn handle_wasm_error(&self, error: anyhow::Error) -> Error {
+    pub fn handle_wasm_error(&self, error: wasmtime::Error) -> Error {
         if let Ok(Some(error)) = self.take_last_error() {
             error
         } else if let Some(exit) = error.downcast_ref::<I32Exit>() {
@@ -431,7 +431,7 @@ impl ResourceLimiter for TrackingResourceLimiter {
         current: usize,
         desired: usize,
         maximum: Option<usize>,
-    ) -> anyhow::Result<bool> {
+    ) -> wasmtime::Result<bool> {
         let res = self.inner.memory_growing(current, desired, maximum);
 
         // Update max_linear_memory_consumed
@@ -457,16 +457,16 @@ impl ResourceLimiter for TrackingResourceLimiter {
         current: usize,
         desired: usize,
         maximum: Option<usize>,
-    ) -> anyhow::Result<bool> {
+    ) -> wasmtime::Result<bool> {
         self.inner.table_growing(current, desired, maximum)
     }
 
-    fn memory_grow_failed(&mut self, error: anyhow::Error) -> anyhow::Result<()> {
+    fn memory_grow_failed(&mut self, error: wasmtime::Error) -> wasmtime::Result<()> {
         self.linear_memory_limit_hit = true;
         self.inner.memory_grow_failed(error)
     }
 
-    fn table_grow_failed(&mut self, error: anyhow::Error) -> anyhow::Result<()> {
+    fn table_grow_failed(&mut self, error: wasmtime::Error) -> wasmtime::Result<()> {
         self.inner.table_grow_failed(error)
     }
 

--- a/ext/src/ruby_api/table.rs
+++ b/ext/src/ruby_api/table.rs
@@ -4,8 +4,6 @@ use super::{
     store::{Store, StoreContextValue},
 };
 
-use anyhow::anyhow;
-
 use crate::{define_rb_intern, error};
 use magnus::{
     class, function, gc::Marker, method, prelude::*, scan_args, typed_data::Obj, DataTypeFunctions,

--- a/ext/src/ruby_api/trap.rs
+++ b/ext/src/ruby_api/trap.rs
@@ -96,10 +96,10 @@ impl From<Trap> for Error {
     }
 }
 
-impl TryFrom<anyhow::Error> for Trap {
-    type Error = anyhow::Error;
+impl TryFrom<wasmtime::Error> for Trap {
+    type Error = wasmtime::Error;
 
-    fn try_from(value: anyhow::Error) -> Result<Self, Self::Error> {
+    fn try_from(value: wasmtime::Error) -> Result<Self, Self::Error> {
         match value.downcast_ref::<wasmtime::Trap>() {
             Some(trap) => {
                 let trap = trap.to_owned();


### PR DESCRIPTION
Instead, rely on wasmtime's re-exported `anyhow::Result` and `anyhow::Error`. One less package to update, and no need to keep version in sync.