### PR TITLE
Replace `Instance#invoke` with `Func#call`

### DIFF
--- a/bench/component_id.rb
+++ b/bench/component_id.rb
@@ -6,14 +6,16 @@ Bench.ips do |x|
   component = Wasmtime::Component::Component.from_file(engine, "spec/fixtures/component_types.wasm")
   store = Wasmtime::Store.new(engine)
   instance = linker.instantiate(store, component)
+  id_record = instance.get_func("id-record")
+  id_u32 = instance.get_func("id-u32")
 
   point_record = {"x" => 1, "y" => 2}
 
   x.report("identity point record") do
-    instance.invoke("id-record", point_record)
+    id_record.call(point_record)
   end
 
   x.report("identity u32") do
-    instance.invoke("id-u32", 10)
+    id_u32.call(10)
   end
 end

--- a/ext/src/ruby_api/component.rs
+++ b/ext/src/ruby_api/component.rs
@@ -161,6 +161,7 @@ pub fn init(ruby: &Ruby) -> Result<(), Error> {
 
     linker::init(ruby, &namespace)?;
     instance::init(ruby, &namespace)?;
+    func::init(ruby, &namespace)?;
     convert::init(ruby)?;
 
     Ok(())

--- a/ext/src/ruby_api/component/func.rs
+++ b/ext/src/ruby_api/component/func.rs
@@ -1,35 +1,118 @@
-use super::convert::{component_val_to_rb, rb_to_component_val};
-use crate::ruby_api::{errors::ExceptionMessage, store::StoreContextValue};
-use magnus::{exception::arg_error, prelude::*, value, Error, IntoValue, RArray, Value};
+use crate::ruby_api::{
+    component::{
+        convert::{component_val_to_rb, rb_to_component_val},
+        Instance,
+    },
+    errors::ExceptionMessage,
+    store::{Store, StoreContextValue},
+};
+use magnus::{
+    class, exception::arg_error, gc::Marker, method, prelude::*, typed_data::Obj, value,
+    DataTypeFunctions, Error, IntoValue, RArray, RModule, Ruby, TypedData, Value,
+};
 use wasmtime::component::{Func as FuncImpl, Type, Val};
 
-pub struct Func;
+/// @yard
+/// @rename Wasmtime::Component::Func
+/// Represents a WebAssembly component Function
+/// @see https://docs.wasmtime.dev/api/wasmtime/component/struct.Func.html Wasmtime's Rust doc
+///
+/// == Component model types conversion
+///
+/// Here's how component model types map to Ruby objects:
+///
+/// bool::
+///     Ruby +true+ or +false+, no automatic conversion happens.
+/// s8, u8, s16, u16, etc.::
+///     Ruby +Integer+. Overflows raise.
+/// f32, f64::
+///     Ruby +Float+.
+/// string::
+///     Ruby +String+. Exception will be raised if the string is not valid UTF-8.
+/// list<T>::
+///     Ruby +Array+.
+/// tuple::
+///     Ruby +Array+ of the same size of tuple. Example: +tuple<T, U>+ would be converted to +[T, U]+.
+/// record::
+///     Ruby +Hash+ where field names are +String+s.
+/// result<O, E>::
+///     {Result} instance. When converting a result branch of the none
+///     type, the {Result}’s value MUST be +nil+.
+///
+///     Examples of none type in a result: unparametrized +result+, +result<O>+, +result<_, E>+.
+/// option<T>::
+///     +nil+ is mapped to +None+, anything else is mapped to +Some(T)+.
+/// flags::
+///     Ruby +Array+ of +String+s.
+/// enum::
+///     Ruby +String+. Exception will be raised of the +String+ is not a valid enum value.
+/// variant::
+///     {Variant} instance wrapping the variant's name and optionally its value.
+///     Exception will be raised for:
+///     - invalid {Variant#name},
+///     - unparametrized variant and not nil {Variant#value}.
+/// resource (own<T> or borrow<T>)::
+///     Not yet supported.
+#[derive(TypedData)]
+#[magnus(class = "Wasmtime::Component::Func", size, mark, free_immediately)]
+pub struct Func {
+    store: Obj<Store>,
+    instance: Obj<Instance>,
+    inner: FuncImpl,
+}
+unsafe impl Send for Func {}
+
+impl DataTypeFunctions for Func {
+    fn mark(&self, marker: &Marker) {
+        marker.mark(self.store);
+        marker.mark(self.instance);
+    }
+}
 
 impl Func {
-    pub fn invoke(
-        store: &StoreContextValue,
-        func: &FuncImpl,
-        args: &[Value],
-    ) -> Result<Value, Error> {
-        let results_ty = func.results(store.context()?);
-        let mut results = vec![wasmtime::component::Val::Bool(false); results_ty.len()];
-        let params = convert_params(store, &func.params(store.context()?), args)?;
+    /// @yard
+    /// Calls a Wasm component model function.
+    /// @def call(*args)
+    /// @param args [Array<Object>] the function's arguments as per its Wasm definition
+    /// @return [Object] the function's return value as per its Wasm definition
+    /// @see Func Func class-level documentation for type conversion logic
+    pub fn call(&self, args: &[Value]) -> Result<Value, Error> {
+        Func::invoke(self.store, &self.inner, args)
+    }
 
-        func.call(store.context_mut()?, &params, &mut results)
-            .map_err(|e| store.handle_wasm_error(e))?;
+    pub fn from_inner(inner: FuncImpl, instance: Obj<Instance>, store: Obj<Store>) -> Self {
+        Self {
+            store,
+            instance,
+            inner,
+        }
+    }
+
+    pub fn invoke(store: Obj<Store>, func: &FuncImpl, args: &[Value]) -> Result<Value, Error> {
+        let store_context_value = StoreContextValue::from(store);
+        let results_ty = func.results(store.context_mut());
+        let mut results = vec![wasmtime::component::Val::Bool(false); results_ty.len()];
+        let params = convert_params(
+            &store_context_value,
+            &func.params(store.context_mut()),
+            args,
+        )?;
+
+        func.call(store.context_mut(), &params, &mut results)
+            .map_err(|e| store_context_value.handle_wasm_error(e))?;
 
         let result = match results_ty.len() {
             0 => Ok(value::qnil().as_value()),
-            1 => component_val_to_rb(results.into_iter().next().unwrap(), store),
+            1 => component_val_to_rb(results.into_iter().next().unwrap(), &store_context_value),
             _ => results
                 .into_iter()
-                .map(|val| component_val_to_rb(val, store))
+                .map(|val| component_val_to_rb(val, &store_context_value))
                 .collect::<Result<RArray, Error>>()
                 .map(IntoValue::into_value),
         };
 
-        func.post_return(store.context_mut()?)
-            .map_err(|e| store.handle_wasm_error(e))?;
+        func.post_return(store.context_mut())
+            .map_err(|e| store_context_value.handle_wasm_error(e))?;
 
         result
     }
@@ -64,4 +147,11 @@ fn convert_params(
     }
 
     Ok(params)
+}
+
+pub fn init(_ruby: &Ruby, namespace: &RModule) -> Result<(), Error> {
+    let func = namespace.define_class("Func", class::object())?;
+    func.define_method("call", method!(Func::call, -1))?;
+
+    Ok(())
 }

--- a/spec/fixtures/component_adder.wat
+++ b/spec/fixtures/component_adder.wat
@@ -1,12 +1,22 @@
 (component
-  (core module $m
-    (func (export "add") (param $a i32) (param $b i32) (result i32)
-      local.get $a
-      local.get $b
-      i32.add
+  ;; Define a nested component so we can export an instance of a component
+  (component $c
+    (core module $m
+        (func (export "add") (param $a i32) (param $b i32) (result i32)
+        local.get $a
+        local.get $b
+        i32.add
+        )
     )
+    (core instance $i (instantiate $m))
+    (func $add (param "a" s32) (param "b" s32) (result s32) (canon lift (core func $i "add")))
+    (export "add" (func $add))
   )
-  (core instance $i (instantiate $m))
-  (func $add (param "a" s32) (param "b" s32) (result s32) (canon lift (core func $i "add")))
-  (export "add" (func $add))
+  (instance $adder (instantiate $c))
+
+  ;; Export the adder instance
+  (export "adder" (instance $adder))
+
+  ;; Re-export add as a top level
+  (export "add" (func $adder "add"))
 )

--- a/spec/unit/component/func_spec.rb
+++ b/spec/unit/component/func_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+module Wasmtime
+  module Component
+    RSpec.describe Func do
+      before(:all) do
+        @adder_component = Component.from_file(GLOBAL_ENGINE, "spec/fixtures/component_adder.wat")
+        @trap_component = Component.from_file(GLOBAL_ENGINE, "spec/fixtures/component_trap.wat")
+      end
+
+      let(:linker) { Linker.new(engine) }
+      let(:add) { linker.instantiate(store, @adder_component).get_func("add") }
+      let(:unreachable) { linker.instantiate(store, @trap_component).get_func("unreachable") }
+
+      describe "#call" do
+        it "calls the func" do
+          expect(add.call(1, 2)).to eq(3)
+        end
+
+        it "allows multiple calls into the same component instance" do
+          expect(add.call(1, 2)).to eq(3)
+          expect(add.call(1, 2)).to eq(3)
+        end
+
+        it "raises on invalid arg count" do
+          expect { add.call(1) }
+            .to raise_error(ArgumentError, /(given 1, expected 2)/)
+        end
+
+        it "raises on invalid arg type" do
+          expect { add.call(nil, nil) }
+            .to raise_error(TypeError, "no implicit conversion of nil into Integer (param at index 0)")
+        end
+
+        it "raises trap when component traps" do
+          expect { unreachable.call }.to raise_error(Trap) do |trap|
+            expect(trap.code).to eq(Trap::UNREACHABLE_CODE_REACHED)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Following the rust crate API, `Instance#invoke` is removed and replaced with 2 calls: `Instance#get_func` and `Func#call`.

Other notable changes:
- Wasm component types <-> Ruby conversion is now documented under `Func`. I ran into Yard limitations when trying to style certain things, but I think it renders well enough:

<img width="1532" alt="type-conversion" src="https://github.com/user-attachments/assets/4ba69336-305b-447e-89d0-21604871daa2">


- `Instance#get_func` supports nested exports by accepting an array of strings.

  ```ruby
  instance.get_func("foo") # looks up the `foo` export
  instance.get_func(["bar", "baz"]) # looks up the `bar` export, then `baz`
  ```

  This API can be extended later to accept an instance of `ExportIndex` to avoid the cost of comparing exports by name each time, like the Rust API. For example:
  
  ```ruby
  index = component.get_export("foo") # or get_export(["bar", "baz"])
  # => #<Wasmtime::Component::ComponentExportIndex ...>
  instance.get_func(index)
  ```