### PR TITLE
chore: Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,17 +42,22 @@ jobs:
 
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.3.5"
           bundler-cache: true
           cargo-cache: true
           cargo-vendor: true
           cache-version: v1-${{ matrix.ruby-platform }}
 
-      - uses: oxidize-rb/cross-gem-action@main
+      - uses: oxidize-rb/actions/cross-gem@v1
+        id: cross-gem
         with:
-          version: latest
           platform: ${{ matrix.ruby-platform }}
           ruby-versions: ${{ join(fromJSON(needs.ci-data.outputs.result).stable-ruby-versions, ', ') }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cross-gem-${{ matrix.platform }}
+          path: ${{ steps.cross-gem.outputs.gem-path }}
 
       - name: Smoke gem install
         if: matrix.ruby-platform == 'x86_64-linux' # GitHub actions architecture
@@ -71,18 +76,14 @@ jobs:
 
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.3.5"
           bundler-cache: true
           cargo-cache: true
           cache-version: v1
 
-      # It seems that v4 is not compatible with how artifacts are uploaded by
-      # oxidize-rb/cross-gem-action. So this must stay as v3 until the issue
-      # below is fixed.
-      # See https://github.com/oxidize-rb/actions/issues/27, for more details.
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: cross-gem
+          pattern: cross-gem-*
 
       - name: Package source gem
         run: bundle exec rake pkg:ruby


### PR DESCRIPTION
This commit attempts to address
https://github.com/bytecodealliance/wasmtime-rb/issues/418, which is currently blocking release. This change pretty much includes all the suggestions in the linked issue.

Additionally, this change makes use of @actions/download-artifact@v4. Given that the new cross-gem action gives us control over how to upload the gem artifacts, download-artifact should now be compatible. It's also worth noting that download-artifact@v3 was deprecated on Nov 30th 2024 https://github.com/actions/download-artifact?tab=readme-ov-file#actionsdownload-artifact