### PR TITLE
Update cross-gem action

### DIFF
--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -40,28 +40,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.4"
-          bundler-cache: true
-          cargo-cache: true
-          cargo-vendor: true
-          cache-version: v2-${{ matrix.ruby-platform }}
 
-      - name: Set vars
-        id: vars
-        run: |
-          echo "rb-sys-version=$(bundle exec ruby -rrb_sys -e 'puts RbSys::VERSION')" >> $GITHUB_OUTPUT
-
-      - uses: oxidize-rb/cross-gem-action@main
+      - uses: oxidize-rb/actions/cross-gem@v1
+        id: cross-gem
         with:
-          version: ${{ steps.vars.outputs.rb-sys-version }}
           platform: ${{ matrix.ruby-platform }}
-          ruby-versions: ${{ join(fromJSON(needs.ci-data.outputs.result).stable-ruby-versions, ', ') }}
+          ruby-versions: ${{ join(fromJSON(needs.ci-data.outputs.result).stable-ruby-versions, ',') }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cross-gem-${{ matrix.ruby-platform }}
+          path: ${{ steps.cross-gem.outputs.gem-path }}
+          if-no-files-found: error
 
       - name: Smoke gem install
         if: matrix.ruby-platform == 'x86_64-linux' # GitHub actions architecture
-        run: bundle exec rake pkg:${{ matrix.ruby-platform }}:test
+        run: bundle install && bundle exec rake pkg:${{ matrix.ruby-platform }}:test
 
   source:
     name: Build source gem

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,19 +40,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
-          bundler-cache: true
-          cargo-cache: true
-          cargo-vendor: true
-          cache-version: v1-${{ matrix.ruby-platform }}
+          ruby-version: "3.4"
 
-      - uses: oxidize-rb/cross-gem-action@main
+      - uses: oxidize-rb/actions/cross-gem@v1
+        id: cross-gem
         with:
-          version: latest
           platform: ${{ matrix.ruby-platform }}
-          ruby-versions: ${{ join(fromJSON(needs.ci-data.outputs.result).stable-ruby-versions, ', ') }}
+          ruby-versions: ${{ join(fromJSON(needs.ci-data.outputs.result).stable-ruby-versions, ',') }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cross-gem-${{ matrix.ruby-platform }}
+          path: pkg/*-${{ matrix.ruby-platform }}.gem
+          if-no-files-found: error
 
       - name: Smoke gem install
         if: matrix.ruby-platform == 'x86_64-linux' # GitHub actions architecture
@@ -71,18 +73,16 @@ jobs:
 
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           bundler-cache: true
           cargo-cache: true
           cache-version: v1
 
-      # It seems that v4 is not compatible with how artifacts are uploaded by
-      # oxidize-rb/cross-gem-action. So this must stay as v3 until the issue
-      # below is fixed.
-      # See https://github.com/oxidize-rb/actions/issues/27, for more details.
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: cross-gem
+          pattern: cross-gem-*
+          merge-multiple: true
+          path: pkg/
 
       - name: Package source gem
         run: bundle exec rake pkg:ruby

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,18 +1371,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.107"
+version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56aaf81d9efc195606456e91896297ee5ab2002381539f8ed1ba6b4f2e467f3b"
+checksum = "1e955384e1a4dc64b71d1e4b39ed0edbd77c7bde4a10dfd5ad208e1160fddfa7"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.107"
+version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "035b513baded6df2b90a8559efb1973c47ba42e16c21c5f0863dd2aa4dbd6abe"
+checksum = "c167c6571889b2550d6fcb315e8aa60bdb95e47e4b64793e3f65a30dc25afc85"
 dependencies = [
  "bindgen",
  "lazy_static",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     wasmtime (28.0.0)
-      rb_sys (~> 0.9.107)
+      rb_sys (~> 0.9.108)
 
 GEM
   remote: https://rubygems.org/
@@ -38,7 +38,7 @@ GEM
     rake (13.2.1)
     rake-compiler (1.2.9)
       rake
-    rb_sys (0.9.107)
+    rb_sys (0.9.108)
     regexp_parser (2.10.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)

--- a/wasmtime.gemspec
+++ b/wasmtime.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.rdoc_options += ["--exclude", "vendor"]
 
-  spec.add_dependency "rb_sys", "~> 0.9.107"
+  spec.add_dependency "rb_sys", "~> 0.9.108"
 end


### PR DESCRIPTION
Update cross-gem action, should fix #418.

Changes:
- Update the cross-gem action the release and build-gem workflows
- Update to latest upload+download artifacts
- Replace yet another Ruby 3.3 by Ruby 3.4
- Update rb-sys to fix the compilation getting killed (issue described in #418)


This _should_ work; I ran a similar workflow that included https://github.com/oxidize-rb/rb-sys/pull/487 and all the *.gem were generated, in the right folder, and had precompiled binaries for all Ruby versions ([code](https://github.com/jbourassa/wasmtime-rb/blob/3b2c7977592d068a8333058e17d128d057bb71f7/.github/workflows/release.yml), [run](https://github.com/jbourassa/wasmtime-rb/actions/runs/12756437467/job/35555185886))