### PR TITLE
Add Fiddle to the development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :development do
   gem "yard", require: false
   gem "yard-rustdoc", "~> 0.4.0", require: false
   gem "benchmark-ips", require: false
+  gem "fiddle"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,7 @@ GEM
     ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
     ffi (1.17.1-x86_64-linux-musl)
+    fiddle (1.1.6)
     get_process_mem (1.0.0)
       bigdecimal (>= 2.0)
       ffi (~> 1.0)
@@ -106,6 +107,7 @@ PLATFORMS
 
 DEPENDENCIES
   benchmark-ips
+  fiddle
   get_process_mem
   rake (~> 13.2)
   rake-compiler


### PR DESCRIPTION
When running the tests on Ruby 3.4, I get the following warning w/ Ruby 3.4:

>~/.rubies/3.4.1/lib/ruby/3.4.0/fiddle.rb:4: warning: fiddle.so was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
>You can add fiddle to your Gemfile or gemspec to silence this warning.

I'm adding this as a development dependency given fiddle usage is optional. Should the user also want to use it, they can opt-in by adding fiddle to their gemfile.