### PR TITLE
Stop running CI on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,6 @@ name: CI
 
 on:
   workflow_dispatch:
-  push:
-    branches: ["**"]
-    tags-ignore: ["v**"] # Skip CI for releases
   pull_request:
 
 concurrency:


### PR DESCRIPTION
Running CI on push and PR is wasteful: for PRs from `wasmtime/wasmtime-rb` branches, we end up running CI twice:

<img width="1098" alt="Screenshot 2025-02-06 at 10 27 28" src="https://github.com/user-attachments/assets/bf3cce62-5e99-47a1-8fb1-34e42b9b9046" />




The downside of this is that we can no longer have a CI run without a PR. But now that CI has draft PRs, it's not really a concern.