### PR TITLE
Remove note on experimental component support

### DIFF
--- a/ext/src/ruby_api/component.rs
+++ b/ext/src/ruby_api/component.rs
@@ -28,7 +28,6 @@ use crate::{
 /// @yard
 /// @rename Wasmtime::Component::Component
 /// Represents a WebAssembly component.
-/// @note Support for Wasm components in the Ruby bindings is experimental. APIs may change in the future.
 /// @see https://docs.rs/wasmtime/latest/wasmtime/component/struct.Component.html Wasmtime's Rust doc
 #[magnus::wrap(
     class = "Wasmtime::Component::Component",

--- a/lib/wasmtime/component.rb
+++ b/lib/wasmtime/component.rb
@@ -2,7 +2,6 @@
 return if defined?(Wasmtime::Component::Result)
 
 module Wasmtime
-  # @note Support for Wasm components in the Ruby bindings is experimental. APIs may change in the future.
   module Component
     # Represents a component model's +result<O, E>+ type.
     class Result


### PR DESCRIPTION
When I initially introduced this note, the APIs were likely to change as I was iterating on the design. Now that the initial APIs are there and there's basic support for components, I think we can remove this mention.