### PR TITLE
Use wasmtime-wasi APIs instead of wasi-common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "deterministic-wasi-ctx"
-version = "0.1.34"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318454bf8047a401ed1d3b276e74c1f2d4ac3e228a52bd4bba6a9dfcd220540f"
+checksum = "5a9ed6b310beac1ae654381707d2c060a4c107cc3fe4ae14e498413c522678ee"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -495,7 +495,6 @@ dependencies = [
  "rand_core",
  "rand_pcg",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasi-common",
  "wasmtime",
  "wasmtime-wasi",
 ]
@@ -2275,6 +2274,8 @@ name = "wasmtime-rb"
 version = "9.0.4"
 dependencies = [
  "async-timer",
+ "async-trait",
+ "bytes",
  "cap-std",
  "deterministic-wasi-ctx",
  "lazy_static",

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -19,6 +19,8 @@ ruby-api = []
 winch = ["wasmtime/winch"]
 
 [dependencies]
+async-trait = "*"
+bytes = "*"
 lazy_static = "1.5.0"
 magnus = { version = "0.7", features = ["rb-sys"] }
 rb-sys = { version = "*", default-features = false, features = [
@@ -40,7 +42,7 @@ async-timer = { version = "1.0.0-beta.15", features = [
 ], optional = true }
 static_assertions = "1.1.0"
 wasmtime-environ = "=31.0.0"
-deterministic-wasi-ctx = "=0.1.34"
+deterministic-wasi-ctx = "=1.0.0"
 
 [build-dependencies]
 rb-sys-env = "0.2.2"

--- a/ext/src/helpers/file_stdin_stream.rs
+++ b/ext/src/helpers/file_stdin_stream.rs
@@ -1,0 +1,25 @@
+use std::sync::Arc;
+
+use wasmtime_wasi::{FileInputStream, StdinStream};
+
+pub struct FileStdinStream {
+    file: Arc<File>,
+}
+
+impl FileStdinStream {
+    pub fn new(file: File) -> Self {
+        Self {
+            file: Arc::new(file),
+        }
+    }
+}
+
+impl StdinStream for FileStdinStream {
+    fn stream(&self) -> Box<dyn wasmtime_wasi::InputStream> {
+        Box::new(FileInputStream::new(Arc::clone(&self.file), 0))
+    }
+
+    fn isatty(&self) -> bool {
+        false
+    }
+}

--- a/ext/src/helpers/mod.rs
+++ b/ext/src/helpers/mod.rs
@@ -1,3 +1,4 @@
+mod file_stdin_stream;
 mod macros;
 mod nogvl;
 mod output_limited_buffer;
@@ -5,8 +6,9 @@ mod static_id;
 mod symbol_enum;
 mod tmplock;
 
+pub use file_stdin_stream::FileStdinStream;
 pub use nogvl::nogvl;
-pub use output_limited_buffer::OutputLimitedBuffer;
+pub use output_limited_buffer::{OutputLimitedBuffer, WritePipe};
 pub use static_id::StaticId;
 pub use symbol_enum::SymbolEnum;
 pub use tmplock::Tmplock;

--- a/ext/src/ruby_api/linker.rs
+++ b/ext/src/ruby_api/linker.rs
@@ -54,8 +54,10 @@ impl Linker {
 
         let mut inner: LinkerImpl<StoreData> = LinkerImpl::new(engine.get());
         if wasi {
-            wasi_common::sync::add_to_linker(&mut inner, |s| s.wasi_ctx_mut())
-                .map_err(|e| error!("{}", e))?
+            wasmtime_wasi::preview0::add_to_linker_sync(&mut inner, |s| s.wasi_ctx_mut())
+                .map_err(|e| error!("{}", e))?;
+            wasmtime_wasi::preview1::add_to_linker_sync(&mut inner, |s| s.wasi_ctx_mut())
+                .map_err(|e| error!("{}", e))?;
         }
         Ok(Self {
             inner: RefCell::new(inner),

--- a/ext/src/ruby_api/store.rs
+++ b/ext/src/ruby_api/store.rs
@@ -15,11 +15,12 @@ use rb_sys::tracking_allocator::{ManuallyTracked, TrackingAllocator};
 use std::borrow::Borrow;
 use std::cell::UnsafeCell;
 use std::convert::TryFrom;
-use wasi_common::{I32Exit, WasiCtx as WasiCtxImpl};
 use wasmtime::{
     AsContext, AsContextMut, ResourceLimiter, Store as StoreImpl, StoreContext, StoreContextMut,
     StoreLimits, StoreLimitsBuilder,
 };
+use wasmtime_wasi::preview1::WasiP1Ctx as WasiCtxImpl;
+use wasmtime_wasi::I32Exit;
 
 define_rb_intern!(
     WASI_CTX => "wasi_ctx",

--- a/ext/src/ruby_api/wasi_ctx.rs
+++ b/ext/src/ruby_api/wasi_ctx.rs
@@ -5,19 +5,15 @@ use super::{
 };
 use crate::error;
 use crate::helpers::OutputLimitedBuffer;
-use deterministic_wasi_ctx::build_wasi_ctx as wasi_deterministic_ctx;
 use magnus::{
     class, function, gc::Marker, method, prelude::*, typed_data::Obj, Error, Object, RString,
     RTypedData, Ruby, TypedData, Value,
 };
 use std::{borrow::Borrow, cell::RefCell, fs::File, path::PathBuf};
-use wasi_common::pipe::{ReadPipe, WritePipe};
-use wasi_common::WasiCtx as WasiCtxImpl;
+use wasmtime_wasi::preview1::WasiP1Ctx as WasiCtxImpl;
 
 /// @yard
 /// WASI context to be sent as {Store#new}’s +wasi_ctx+ keyword argument.
-///
-/// Instance methods mutate the current object and return +self+.
 ///
 /// @see https://docs.rs/wasmtime-wasi/latest/wasmtime_wasi/struct.WasiCtx.html
 ///   Wasmtime's Rust doc
@@ -29,96 +25,6 @@ pub struct WasiCtx {
 type RbSelf = Obj<WasiCtx>;
 
 impl WasiCtx {
-    /// @yard
-    /// Create a new deterministic {WasiCtx}. See https://github.com/Shopify/deterministic-wasi-ctx for more details
-    /// @return [WasiCtx]
-    pub fn deterministic() -> Self {
-        Self {
-            inner: RefCell::new(wasi_deterministic_ctx()),
-        }
-    }
-
-    /// @yard
-    /// Set stdin to read from the specified file.
-    /// @def set_stdin_file(path)
-    /// @param path [String] The path of the file to read from.
-    /// @return [WasiCtxBuilder] +self+
-    fn set_stdin_file(rb_self: RbSelf, path: RString) -> RbSelf {
-        let inner = rb_self.inner.borrow_mut();
-        let cs = file_r(path).map(wasi_file).unwrap();
-        inner.set_stdin(cs);
-        rb_self
-    }
-
-    /// @yard
-    /// Set stdin to the specified String.
-    /// @def set_stdin_string(content)
-    /// @param content [String]
-    /// @return [WasiCtx] +self+
-    fn set_stdin_string(rb_self: RbSelf, content: RString) -> RbSelf {
-        let inner = rb_self.inner.borrow_mut();
-        let str = unsafe { content.as_slice() };
-        let pipe = ReadPipe::from(str);
-        inner.set_stdin(Box::new(pipe));
-        rb_self
-    }
-
-    /// @yard
-    /// Set stdout to write to a file. Will truncate the file if it exists,
-    /// otherwise try to create it.
-    /// @def set_stdout_file(path)
-    /// @param path [String] The path of the file to write to.
-    /// @return [WasiCtx] +self+
-    fn set_stdout_file(rb_self: RbSelf, path: RString) -> RbSelf {
-        let inner = rb_self.inner.borrow_mut();
-        let cs = file_w(path).map(wasi_file).unwrap();
-        inner.set_stdout(cs);
-        rb_self
-    }
-
-    /// @yard
-    /// Set stdout to write to a string buffer.
-    /// If the string buffer is frozen, Wasm execution will raise a Wasmtime::Error error.
-    /// No encoding checks are done on the resulting string, it is the caller's responsibility to ensure the string contains a valid encoding
-    /// @def set_stdout_buffer(buffer, capacity)
-    /// @param buffer [String] The string buffer to write to.
-    /// @param capacity [Integer] The maximum number of bytes that can be written to the output buffer.
-    /// @return [WasiCtx] +self+
-    fn set_stdout_buffer(rb_self: RbSelf, buffer: RString, capacity: usize) -> RbSelf {
-        let inner = rb_self.inner.borrow_mut();
-        let pipe = WritePipe::new(OutputLimitedBuffer::new(buffer.into(), capacity));
-        inner.set_stdout(Box::new(pipe));
-        rb_self
-    }
-
-    /// @yard
-    /// Set stderr to write to a file. Will truncate the file if it exists,
-    /// otherwise try to create it.
-    /// @def set_stderr_file(path)
-    /// @param path [String] The path of the file to write to.
-    /// @return [WasiCtx] +self+
-    fn set_stderr_file(rb_self: RbSelf, path: RString) -> RbSelf {
-        let inner = rb_self.inner.borrow_mut();
-        let cs = file_w(path).map(wasi_file).unwrap();
-        inner.set_stderr(cs);
-        rb_self
-    }
-
-    /// @yard
-    /// Set stderr to write to a string buffer.
-    /// If the string buffer is frozen, Wasm execution will raise a Wasmtime::Error error.
-    /// No encoding checks are done on the resulting string, it is the caller's responsibility to ensure the string contains a valid encoding
-    /// @def set_stderr_buffer(buffer, capacity)
-    /// @param buffer [String] The string buffer to write to.
-    /// @param capacity [Integer] The maximum number of bytes that can be written to the output buffer.
-    /// @return [WasiCtx] +self+
-    fn set_stderr_buffer(rb_self: RbSelf, buffer: RString, capacity: usize) -> RbSelf {
-        let inner = rb_self.inner.borrow_mut();
-        let pipe = WritePipe::new(OutputLimitedBuffer::new(buffer.into(), capacity));
-        inner.set_stderr(Box::new(pipe));
-        rb_self
-    }
-
     pub fn from_inner(inner: WasiCtxImpl) -> Self {
         Self {
             inner: RefCell::new(inner),
@@ -131,13 +37,6 @@ impl WasiCtx {
 }
 
 pub fn init() -> Result<(), Error> {
-    let class = root().define_class("WasiCtx", class::object())?;
-    class.define_singleton_method("deterministic", function!(WasiCtx::deterministic, 0))?;
-    class.define_method("set_stdin_file", method!(WasiCtx::set_stdin_file, 1))?;
-    class.define_method("set_stdin_string", method!(WasiCtx::set_stdin_string, 1))?;
-    class.define_method("set_stdout_file", method!(WasiCtx::set_stdout_file, 1))?;
-    class.define_method("set_stdout_buffer", method!(WasiCtx::set_stdout_buffer, 2))?;
-    class.define_method("set_stderr_file", method!(WasiCtx::set_stderr_file, 1))?;
-    class.define_method("set_stderr_buffer", method!(WasiCtx::set_stderr_buffer, 2))?;
+    root().define_class("WasiCtx", class::object())?;
     Ok(())
 }


### PR DESCRIPTION
This is not ready, it will not compile.

This is my work in progress for switching `wasmtime-rb` to use `wasmtime-wasi` APIs instead of `wasi-common`. This will involve having to make breaking API changes because the `wasmtime-wasi` APIs are quite different from `wasi-common`'s. Particularly around not being able to change the `stdio` streams after creating a `WasiP1Ctx`.