### PR TITLE
Drop support for WASI preview 0

### DIFF
--- a/ext/src/ruby_api/linker.rs
+++ b/ext/src/ruby_api/linker.rs
@@ -54,8 +54,11 @@ impl Linker {
 
         let mut inner: LinkerImpl<StoreData> = LinkerImpl::new(engine.get());
         if wasi {
-            wasi_common::sync::add_to_linker(&mut inner, |s| s.wasi_ctx_mut())
-                .map_err(|e| error!("{}", e))?
+            wasi_common::sync::snapshots::preview_1::add_wasi_snapshot_preview1_to_linker(
+                &mut inner,
+                |s| s.wasi_ctx_mut(),
+            )
+            .map_err(|e| error!("{}", e))?
         }
         Ok(Self {
             inner: RefCell::new(inner),

--- a/spec/unit/error_spec.rb
+++ b/spec/unit/error_spec.rb
@@ -114,7 +114,7 @@ module Wasmtime
     def wasi_module_exiting
       Module.new(engine, <<~WAT)
         (module
-          (import "wasi_unstable" "proc_exit"
+          (import "wasi_snapshot_preview1" "proc_exit"
             (func $__wasi_proc_exit (param i32)))
           (memory (export "memory") 0)
           (func $_start


### PR DESCRIPTION
I don't see a good reason to continue supporting WASI preview 0. We'll need to remove support at some point in the future given Wasmtime will eventually not provide support for these APIs. Given the work to migrate from `wasi-common` to `wasmtime-wasi`, I think now is a good time to remove wasmtime-rb's support for these APIs.