### PR TITLE
Add rust-toolchain.toml to address failing build native gems

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "stable"
+components = ["clippy", "rustfmt"]
+targets = ["wasm32-wasip1"]
+profile = "default"


### PR DESCRIPTION
I think specifying this file should cause the current stable toolchain to be used which could fix #479. See https://github.com/jeffcharles/wasmtime-rb/actions/runs/16029783762/job/45227084441#step:4:447 for what this did on my fork of the repo for the _Build native gems_ workflow where it's failing on main.