### PR TITLE
s/WASM/Wasm

### DIFF
--- a/ext/src/ruby_api/engine.rs
+++ b/ext/src/ruby_api/engine.rs
@@ -78,7 +78,7 @@ impl Engine {
     /// @option config [Boolean] :wasm_multi_memory
     /// @option config [Boolean] :wasm_memory64
     /// @option config [Boolean] :wasm_reference_types
-    /// @option config [Boolean] :parallel_compilation (true) Whether compile WASM using multiple threads
+    /// @option config [Boolean] :parallel_compilation (true) Whether compile Wasm using multiple threads
     /// @option config [Boolean] :generate_address_map Configures whether compiled artifacts will contain information to map native program addresses back to the original wasm module. This configuration option is `true` by default. Disabling this feature can result in considerably smaller serialized modules.
     /// @option config [Symbol] :cranelift_opt_level One of +none+, +speed+, +speed_and_size+.
     /// @option config [Symbol] :profiler One of +none+, +jitdump+, +vtune+.

--- a/ext/src/ruby_api/memory/unsafe_slice.rs
+++ b/ext/src/ruby_api/memory/unsafe_slice.rs
@@ -21,7 +21,7 @@ use std::ops::Range;
 /// @yard
 /// @rename Wasmtime::Memory::UnsafeSlice
 /// Represents a slice of a WebAssembly memory. This is useful for creating Ruby
-/// strings from WASM memory without any extra memory allocations.
+/// strings from Wasm memory without any extra memory allocations.
 ///
 /// The returned {UnsafeSlice} lazily reads the underlying memory, meaning that
 /// the actual pointer to the string buffer is not materialzed until


### PR DESCRIPTION
According to https://webassembly.org/, the correct abbreviation is:

	  WebAssembly (abbreviated Wasm)