### PR TITLE
Update oxidize-rb/actions/fetch-ci-data

### DIFF
--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -17,7 +17,7 @@ jobs:
       result: ${{ steps.fetch.outputs.result }}
     steps:
       - id: fetch
-        uses: oxidize-rb/actions/fetch-ci-data@v1
+        uses: oxidize-rb/actions/fetch-ci-data@02b64e04ebb629c9b325137355369f43b1fcfa80
         with:
           supported-ruby-platforms: |
             # Excluding:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       result: ${{ steps.fetch.outputs.result }}
     steps:
       - id: fetch
-        uses: oxidize-rb/actions/fetch-ci-data@v1
+        uses: oxidize-rb/actions/fetch-ci-data@02b64e04ebb629c9b325137355369f43b1fcfa80
         with:
           stable-ruby-versions: |
               # See https://github.com/bytecodealliance/wasmtime-rb/issues/286

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       result: ${{ steps.fetch.outputs.result }}
     steps:
       - id: fetch
-        uses: oxidize-rb/actions/fetch-ci-data@v1
+        uses: oxidize-rb/actions/fetch-ci-data@02b64e04ebb629c9b325137355369f43b1fcfa80
         with:
           supported-ruby-platforms: |
             # Excluding:


### PR DESCRIPTION
To include https://github.com/oxidize-rb/actions/pull/63, which ensures that ruby 3.3 is not overwritten to 3.3.5.

Fixes https://github.com/bytecodealliance/wasmtime-rb/issues/499

In CI, we now see:

```sh
Run oxidize-rb/actions/fetch-ci-data@02b64e04ebb629c9b325137355369f43b1fcfa80
Run : Run query
::info:: Selected Ruby versions: 3.2, 3.3, 3.4
```

Instead of 3.3.5

I'm tempted to wait for https://github.com/oxidize-rb/actions/issues/64 to be released before proceeding with this approach, once v1.4.3 is released, we'd get the changes applied automatically. 