### PR TITLE
Expose `wasm_exceptions` engine option to Ruby

### DIFF
--- a/ext/src/ruby_api/config.rs
+++ b/ext/src/ruby_api/config.rs
@@ -42,6 +42,7 @@ define_rb_intern!(
     POOLING => "pooling",
     ON_DEMAND => "on_demand",
     WASM_REFERENCE_TYPES => "wasm_reference_types",
+    WASM_EXCEPTIONS => "wasm_exceptions",
     ASYNC_STACK_ZEROING => "async_stack_zeroing",
 );
 
@@ -105,6 +106,8 @@ pub fn hash_to_config(hash: RHash) -> Result<Config, Error> {
             config.parallel_compilation(entry.try_into()?);
         } else if *WASM_REFERENCE_TYPES == id {
             config.wasm_reference_types(entry.try_into()?);
+        } else if *WASM_EXCEPTIONS == id {
+            config.wasm_exceptions(entry.try_into()?);
         } else if *PROFILER == id {
             config.profiler(entry.try_into()?);
         } else if *CRANELIFT_OPT_LEVEL == id {

--- a/ext/src/ruby_api/engine.rs
+++ b/ext/src/ruby_api/engine.rs
@@ -78,6 +78,7 @@ impl Engine {
     /// @option config [Boolean] :wasm_multi_memory
     /// @option config [Boolean] :wasm_memory64
     /// @option config [Boolean] :wasm_reference_types
+    /// @option config [Boolean] :wasm_exceptions Whether the WebAssembly exception-handling proposal is enabled.
     /// @option config [Boolean] :parallel_compilation (true) Whether compile Wasm using multiple threads
     /// @option config [Boolean] :generate_address_map Configures whether compiled artifacts will contain information to map native program addresses back to the original wasm module. This configuration option is `true` by default. Disabling this feature can result in considerably smaller serialized modules.
     /// @option config [Symbol] :cranelift_opt_level One of +none+, +speed+, +speed_and_size+.

--- a/spec/unit/engine_spec.rb
+++ b/spec/unit/engine_spec.rb
@@ -29,6 +29,7 @@ module Wasmtime
         [:wasm_memory64, true],
         [:parallel_compilation, true],
         [:wasm_reference_types, true],
+        [:wasm_exceptions, true],
         [:async_stack_zeroing, true]
       ].each do |option, valid, invalid = nil|
         it "supports #{option}" do


### PR DESCRIPTION
Closes #598.

Adds a dispatch arm in `hash_to_config` so the existing `wasmtime::Config::wasm_exceptions` method becomes reachable from `Engine.new`.

## Verification

The reproducer from #598, before:

```
without options      : Wasmtime::Error: Could not build module: failed to parse WebAssembly module
wasm_exceptions: true: ArgumentError: Unknown option: :wasm_exceptions
```

After:

```
without options      : Wasmtime::Error: Could not build module: failed to parse WebAssembly module
wasm_exceptions: true: OK
```
