### PR TITLE
bump rb_sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,18 +1440,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.127"
+version = "0.9.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d7c9560fe42dcffa576941394075f18a17dce89fcf718a2fa90b7dc2134d12"
+checksum = "45ca28513560e56cfb79a62b1fce363c73af170a182024ce880c77ee9429920a"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.127"
+version = "0.9.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1688e8f32967ba48c89e4dfa283b57f901075f542fc7ee9c3d7c5f9091ca1d9"
+checksum = "ce04b2c55eff3a21aaa623fcc655d94373238e72cac6b3e1a3641ff31649f99a"
 dependencies = [
  "bindgen",
  "lazy_static",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     wasmtime (45.0.0)
-      rb_sys (~> 0.9.124)
+      rb_sys (~> 0.9.128)
 
 GEM
   remote: https://rubygems.org/
@@ -48,7 +48,7 @@ GEM
     rake-compiler (1.3.1)
       rake
     rake-compiler-dock (1.12.0)
-    rb_sys (0.9.127)
+    rb_sys (0.9.128)
       rake-compiler-dock (= 1.12.0)
     rdoc (7.2.0)
       erb

--- a/wasmtime.gemspec
+++ b/wasmtime.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.rdoc_options += ["--exclude", "vendor"]
 
-  spec.add_dependency "rb_sys", "~> 0.9.124"
+  spec.add_dependency "rb_sys", "~> 0.9.128"
 end


### PR DESCRIPTION
`build-native-gems` is failing on main after the wasmtime bump because wasmtime requires rustc >= 0.93 but the step uses a docker container thats pulling an old version. Bumping the version should fix it.

`build-native-gems` doesn't run on PRs so we didn't catch it there.

Manual trigger https://github.com/bytecodealliance/wasmtime-rb/actions/runs/26407150802