### PR TITLE
Strip debug symbols from gem release shared object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ exclude = [
 
 [profile.release]
 codegen-units = 1 # more llvm optimizations
-debug = 2         # make perfomance engineers happy
+strip = true      # strip debug symbols
 lto = "thin"      # cross-crate inlining


### PR DESCRIPTION
Related issue: https://github.com/bytecodealliance/wasmtime-rb/issues/604 
It reduces ruby gem download size from ~190MB to ~29MB