### PR TITLE
Run smoke tests on os matrix

### DIFF
--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -56,9 +56,43 @@ jobs:
           path: ${{ steps.cross-gem.outputs.gem-path }}
           if-no-files-found: error
 
+  smoke-test:
+    name: Smoke test native gem (${{ matrix.ruby-platform }})
+    needs: native
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ruby-platform: x86_64-linux
+            os: ubuntu-latest
+          - ruby-platform: aarch64-linux
+            os: ubuntu-24.04-arm
+          - ruby-platform: x64-mingw-ucrt
+            os: windows-2025
+          - ruby-platform: aarch64-mingw-ucrt
+            os: windows-11-arm
+          - ruby-platform: x86_64-darwin
+            os: macos-15-intel
+          - ruby-platform: arm64-darwin
+            os: macos-15
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0"
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: cross-gem-${{ matrix.ruby-platform }}
+          path: pkg/
+
       - name: Smoke gem install
-        if: matrix.ruby-platform == 'x86_64-linux' # GitHub actions architecture
-        run: bundle install && bundle exec rake pkg:${{ matrix.ruby-platform }}:test
+        shell: bash
+        run: |
+          gem install pkg/wasmtime-*.gem --verbose
+          script="precompiled = Wasmtime::Engine.new.precompile_module(%q[(module)]); abort %q[missing wasmtime.info section] unless precompiled.include?(%q[wasmtime.info])"
+          ruby -rwasmtime -e "$script"
+          echo "✅ Successfully gem installed"
 
   source:
     name: Build source gem

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,17 +56,47 @@ jobs:
           path: pkg/*-${{ matrix.ruby-platform }}.gem
           if-no-files-found: error
 
+  smoke-test:
+    name: Smoke test native gem (${{ matrix.ruby-platform }})
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ruby-platform: x86_64-linux
+            os: ubuntu-latest
+          - ruby-platform: aarch64-linux
+            os: ubuntu-24.04-arm
+          - ruby-platform: x64-mingw-ucrt
+            os: windows-2025
+          - ruby-platform: aarch64-mingw-ucrt
+            os: windows-11-arm
+          - ruby-platform: x86_64-darwin
+            os: macos-15-intel
+          - ruby-platform: arm64-darwin
+            os: macos-15
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0"
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: cross-gem-${{ matrix.ruby-platform }}
+          path: pkg/
+
       - name: Smoke gem install
-        if: matrix.ruby-platform == 'x86_64-linux' # GitHub actions architecture
+        shell: bash
         run: |
           gem install pkg/wasmtime-*.gem --verbose
-          script="puts Wasmtime::Engine.new.precompile_module('(module)')"
-          ruby -rwasmtime -e "$script" | grep wasmtime.info
+          script="precompiled = Wasmtime::Engine.new.precompile_module(%q[(module)]); abort %q[missing wasmtime.info section] unless precompiled.include?(%q[wasmtime.info])"
+          ruby -rwasmtime -e "$script"
           echo "✅ Successfully gem installed"
 
   release:
     name: Release
-    needs: build
+    needs: [build, smoke-test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
The existing smoke test was just running on `x86_64-linux` which means we failed to catch a loading bug on `x64-mingw-ucrt` https://github.com/bytecodealliance/wasmtime-rb/issues/581. That bug was fixed in https://github.com/bytecodealliance/wasmtime-rb/pull/610 but this PR adds a testing matrix for for the build-gems and release workflows to catch this issues like this in the future.

[Heres](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/27704039299) an example run.